### PR TITLE
La 154 add req resp to kpi event

### DIFF
--- a/src/main/java/com/selina/lending/messaging/event/BrokerRequestKpiEvent.java
+++ b/src/main/java/com/selina/lending/messaging/event/BrokerRequestKpiEvent.java
@@ -29,6 +29,8 @@ public record BrokerRequestKpiEvent(
         String source,
         String uriPath,
         String httpMethod,
+        String httpRequestBody,
+        String httpResponseBody,
         Integer httpResponseCode,
         String decision,
         Instant started,

--- a/src/main/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapper.java
+++ b/src/main/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapper.java
@@ -22,7 +22,7 @@ import com.selina.lending.internal.dto.ApplicationResponse;
 import com.selina.lending.internal.dto.quote.QuickQuoteResponse;
 import com.selina.lending.messaging.event.BrokerRequestKpiEvent;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
@@ -39,71 +39,72 @@ import static com.selina.lending.messaging.publisher.mapper.IPHelper.getRemoteAd
 public class BrokerRequestEventMapper {
 
     private static final String REQUEST_ID_HEADER_NAME = "x-selina-request-id";
-    private static final String QUICK_QUOTE_PATH = "quickquote";
     private final ObjectMapper objectMapper;
 
     public BrokerRequestEventMapper(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-
-    public Optional<BrokerRequestKpiEvent> quickQuoteToKpiEvent(ContentCachingRequestWrapper httpRequest,
-                                                                ContentCachingResponseWrapper httpResponse,
-                                                                Instant started,
-                                                                String clientId) {
-        return Optional.empty();
-    }
-
     public Optional<BrokerRequestKpiEvent> dipToKpiEvent(ContentCachingRequestWrapper httpRequest,
                                                          ContentCachingResponseWrapper httpResponse,
                                                          Instant started,
                                                          String clientId) {
-        String requestId = Optional.ofNullable(httpRequest.getHeader(REQUEST_ID_HEADER_NAME)).orElse(UUID.randomUUID().toString());
-
         try {
-            Pair<String, String> externalAppIdDecision = getExternalApplicationIdAndDecisionPair(httpRequest, httpResponse);
+            var resp = objectMapper.readValue(httpResponse.getContentAsByteArray(), ApplicationResponse.class);
 
-            return (externalAppIdDecision.getLeft() == null || externalAppIdDecision.getRight() == null) ?
-                    Optional.empty() :
-                    Optional.of(BrokerRequestKpiEvent.builder()
-                            .requestId(requestId)
-                            .externalApplicationId(externalAppIdDecision.getLeft())
-                            .source(clientId)
-                            .uriPath(httpRequest.getRequestURI())
-                            .httpMethod(httpRequest.getMethod())
-                            .ip(getRemoteAddr(httpRequest))
-                            .started(started)
-                            .finished(Instant.now())
-                            .decision(externalAppIdDecision.getRight())
-                            .httpResponseCode(httpResponse.getStatus())
-                            .build());
+            if (resp.getApplication() == null || resp.getApplication().getStatus() == null) {
+                return Optional.empty();
+            }
+
+            String externalApplicationId = resp.getApplication().getExternalApplicationId();
+            String decision = resp.getApplication().getStatus();
+
+            return doMapping(httpRequest, httpResponse, started, clientId, externalApplicationId, decision);
         } catch (IOException e) {
             log.error("Can't map event. Reason: {}", e.getMessage());
             return Optional.empty();
         }
     }
 
-    private Pair<String, String> getExternalApplicationIdAndDecisionPair(ContentCachingRequestWrapper httpRequest, ContentCachingResponseWrapper httpResponse)
-            throws IOException {
-        String externalApplicationId = null;
-        String decision = null;
-
-        if (isQuickQuoteRequest(httpRequest)) {
+    public Optional<BrokerRequestKpiEvent> quickQuoteToKpiEvent(ContentCachingRequestWrapper httpRequest,
+                                                                ContentCachingResponseWrapper httpResponse,
+                                                                Instant started,
+                                                                String clientId) {
+        try {
             var resp = objectMapper.readValue(httpResponse.getContentAsByteArray(), QuickQuoteResponse.class);
-            externalApplicationId = resp.getExternalApplicationId();
-            decision = resp.getStatus();
-        } else {
-            var resp = objectMapper.readValue(httpResponse.getContentAsByteArray(), ApplicationResponse.class);
-            if (resp.getApplication() != null) {
-                externalApplicationId = resp.getApplication().getExternalApplicationId();
-                decision = resp.getApplication().getStatus();
-            }
+            String externalApplicationId = resp.getExternalApplicationId();
+            String decision = resp.getStatus();
+
+            return doMapping(httpRequest, httpResponse, started, clientId, externalApplicationId, decision);
+
+        } catch (IOException e) {
+            log.error("Can't map event. Reason: {}", e.getMessage());
+            return Optional.empty();
         }
-        return Pair.of(externalApplicationId, decision);
+
     }
 
-    private boolean isQuickQuoteRequest(ContentCachingRequestWrapper httpRequest) {
-        return httpRequest.getRequestURI().contains(QUICK_QUOTE_PATH);
+    @NotNull
+    private static Optional<BrokerRequestKpiEvent> doMapping(ContentCachingRequestWrapper httpRequest,
+                                                             ContentCachingResponseWrapper httpResponse,
+                                                             Instant started, String clientId,
+                                                             String externalApplicationId,
+                                                             String decision
+    ) {
+        var requestId = Optional.ofNullable(httpRequest.getHeader(REQUEST_ID_HEADER_NAME)).orElse(UUID.randomUUID().toString());
+
+        return Optional.of(BrokerRequestKpiEvent.builder()
+                .requestId(requestId)
+                .externalApplicationId(externalApplicationId)
+                .source(clientId)
+                .uriPath(httpRequest.getRequestURI())
+                .httpMethod(httpRequest.getMethod())
+                .ip(getRemoteAddr(httpRequest))
+                .started(started)
+                .finished(Instant.now())
+                .decision(decision)
+                .httpResponseCode(httpResponse.getStatus())
+                .build());
     }
 
 }

--- a/src/main/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapper.java
+++ b/src/main/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapper.java
@@ -56,10 +56,10 @@ public class BrokerRequestEventMapper {
                 return Optional.empty();
             }
 
-            String externalApplicationId = resp.getApplication().getExternalApplicationId();
+            String externalId = resp.getApplication().getExternalApplicationId();
             String decision = resp.getApplication().getStatus();
 
-            return doMapping(httpRequest, httpResponse, started, clientId, externalApplicationId, decision);
+            return doMapping(httpRequest, httpResponse, started, clientId, externalId, decision);
         } catch (IOException e) {
             log.error("Can't map event. Reason: {}", e.getMessage());
             return Optional.empty();
@@ -72,11 +72,10 @@ public class BrokerRequestEventMapper {
                                                                 String clientId) {
         try {
             var resp = objectMapper.readValue(httpResponse.getContentAsByteArray(), QuickQuoteResponse.class);
-            String externalApplicationId = resp.getExternalApplicationId();
+            String externalId = resp.getExternalApplicationId();
             String decision = resp.getStatus();
 
-            return doMapping(httpRequest, httpResponse, started, clientId, externalApplicationId, decision);
-
+            return doMapping(httpRequest, httpResponse, started, clientId, externalId, decision);
         } catch (IOException e) {
             log.error("Can't map event. Reason: {}", e.getMessage());
             return Optional.empty();
@@ -88,14 +87,14 @@ public class BrokerRequestEventMapper {
     private static Optional<BrokerRequestKpiEvent> doMapping(ContentCachingRequestWrapper httpRequest,
                                                              ContentCachingResponseWrapper httpResponse,
                                                              Instant started, String clientId,
-                                                             String externalApplicationId,
+                                                             String externalId,
                                                              String decision
     ) {
         var requestId = Optional.ofNullable(httpRequest.getHeader(REQUEST_ID_HEADER_NAME)).orElse(UUID.randomUUID().toString());
 
         return Optional.of(BrokerRequestKpiEvent.builder()
                 .requestId(requestId)
-                .externalApplicationId(externalApplicationId)
+                .externalApplicationId(externalId)
                 .source(clientId)
                 .uriPath(httpRequest.getRequestURI())
                 .httpMethod(httpRequest.getMethod())

--- a/src/main/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapper.java
+++ b/src/main/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapper.java
@@ -17,24 +17,22 @@
 
 package com.selina.lending.messaging.publisher.mapper;
 
-import static com.selina.lending.messaging.publisher.mapper.IPHelper.getRemoteAddr;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.selina.lending.internal.dto.ApplicationResponse;
+import com.selina.lending.internal.dto.quote.QuickQuoteResponse;
+import com.selina.lending.messaging.event.BrokerRequestKpiEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.stereotype.Component;
-import org.springframework.web.util.ContentCachingRequestWrapper;
-import org.springframework.web.util.ContentCachingResponseWrapper;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.selina.lending.internal.dto.ApplicationResponse;
-import com.selina.lending.internal.dto.quote.QuickQuoteResponse;
-import com.selina.lending.messaging.event.BrokerRequestKpiEvent;
-
-import lombok.extern.slf4j.Slf4j;
+import static com.selina.lending.messaging.publisher.mapper.IPHelper.getRemoteAddr;
 
 @Slf4j
 @Component
@@ -48,11 +46,18 @@ public class BrokerRequestEventMapper {
         this.objectMapper = objectMapper;
     }
 
-    public Optional<BrokerRequestKpiEvent> toBrokerRequestKpiEvent(
-            ContentCachingRequestWrapper httpRequest,
-            ContentCachingResponseWrapper httpResponse,
-            Instant started,
-            String clientId) {
+
+    public Optional<BrokerRequestKpiEvent> quickQuoteToKpiEvent(ContentCachingRequestWrapper httpRequest,
+                                                                ContentCachingResponseWrapper httpResponse,
+                                                                Instant started,
+                                                                String clientId) {
+        return Optional.empty();
+    }
+
+    public Optional<BrokerRequestKpiEvent> dipToKpiEvent(ContentCachingRequestWrapper httpRequest,
+                                                         ContentCachingResponseWrapper httpResponse,
+                                                         Instant started,
+                                                         String clientId) {
         String requestId = Optional.ofNullable(httpRequest.getHeader(REQUEST_ID_HEADER_NAME)).orElse(UUID.randomUUID().toString());
 
         try {
@@ -100,4 +105,5 @@ public class BrokerRequestEventMapper {
     private boolean isQuickQuoteRequest(ContentCachingRequestWrapper httpRequest) {
         return httpRequest.getRequestURI().contains(QUICK_QUOTE_PATH);
     }
+
 }

--- a/src/test/java/com/selina/lending/api/interceptor/BrokerRequestResolverTest.java
+++ b/src/test/java/com/selina/lending/api/interceptor/BrokerRequestResolverTest.java
@@ -56,10 +56,12 @@ class BrokerRequestResolverTest {
     @Test
     void shouldDoNotPublishEventWheMapperReturnedEmpty() {
         // Given
-        when(mapper.toBrokerRequestKpiEvent(any(), any(), any(), any())).thenReturn(Optional.empty());
+        var request = new MockHttpServletRequest();
+
+        when(mapper.dipToKpiEvent(any(), any(), any(), any())).thenReturn(Optional.empty());
 
         // When
-        resolver.handle(null, null, null);
+        resolver.handle(new ContentCachingRequestWrapper(request), null, null);
 
         // Then
         verifyNoInteractions(publisher);
@@ -72,7 +74,7 @@ class BrokerRequestResolverTest {
         var response = new MockHttpServletResponse();
         var started = Instant.now();
         var event = buildBrokerRequestKpiEvent();
-        when(mapper.toBrokerRequestKpiEvent(any(), any(), any(), any())).thenReturn(Optional.of(event));
+        when(mapper.dipToKpiEvent(any(), any(), any(), any())).thenReturn(Optional.of(event));
 
         // When
         resolver.handle(
@@ -83,5 +85,49 @@ class BrokerRequestResolverTest {
 
         // Then
         verify(publisher, times(1)).publish(event);
+    }
+    
+    @Test
+    void shouldCallQuickQuoteMapperWhenQuickQuoteRequest() {
+        // Given
+        var uriPath = "/application/quickquote";
+        var request = new MockHttpServletRequest();
+        request.setRequestURI(uriPath);
+
+        var response = new MockHttpServletResponse();
+        var started = Instant.now();
+        when(mapper.quickQuoteToKpiEvent(any(), any(), any(), any())).thenReturn(Optional.empty());
+
+        // When
+        resolver.handle(
+                new ContentCachingRequestWrapper(request),
+                new ContentCachingResponseWrapper(response),
+                started
+        );
+
+        // Then
+        verify(mapper, times(1)).quickQuoteToKpiEvent(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldCallDipMapperAsDefault() {
+        // Given
+        var uriPath = "/application/abra-cadabra";
+        var request = new MockHttpServletRequest();
+        request.setRequestURI(uriPath);
+
+        var response = new MockHttpServletResponse();
+        var started = Instant.now();
+        when(mapper.dipToKpiEvent(any(), any(), any(), any())).thenReturn(Optional.empty());
+
+        // When
+        resolver.handle(
+                new ContentCachingRequestWrapper(request),
+                new ContentCachingResponseWrapper(response),
+                started
+        );
+
+        // Then
+        verify(mapper, times(1)).dipToKpiEvent(any(), any(), any(), any());
     }
 }

--- a/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
+++ b/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
@@ -191,7 +191,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
     @Test
     void shouldReturnEmptyWhenCanNotProperlyReadResponse() throws IOException {
         // Given
-        var httpRequest = new MockHttpServletRequest(); // without request-id header
+        var httpRequest = new MockHttpServletRequest();
         var response = new MockHttpServletResponse();
 
         var appRequest = getDIPApplicationRequestDto();
@@ -211,7 +211,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
     }
 
     @Test
-    void shouldReturnEmptyWhenApplicationNotInResponse() throws IOException {
+    void shouldReturnEmptyWhenApplicationNotInDipResponse() throws IOException {
         // Given
         var httpRequest = new MockHttpServletRequest();
         var response = new MockHttpServletResponse();
@@ -235,7 +235,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
     }
 
     @Test
-    void shouldReturnEmptyWhenDecisionNotInResponse() throws IOException {
+    void shouldReturnEmptyWhenDecisionNotInDipResponse() throws IOException {
         // Given
         var httpRequest = new MockHttpServletRequest();
         var response = new MockHttpServletResponse();
@@ -248,6 +248,78 @@ class BrokerRequestEventMapperTest extends MapperBase {
 
         // When
         var optResult = mapper.dipToKpiEvent(
+                new ContentCachingRequestWrapper(httpRequest),
+                new ContentCachingResponseWrapper(response),
+                Instant.now(),
+                "the-broker-id"
+        );
+
+        // Then
+        assertTrue(optResult.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenExternalApplicationIdIsNullInQuickQuoteResponse() throws IOException {
+        // Given
+        var httpRequest = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+
+        var appRequest = getQuickQuoteApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, QuickQuoteApplicationRequest.class)).thenReturn(appRequest);
+
+        QuickQuoteResponse appResponse = QuickQuoteResponse.builder().externalApplicationId(null).build();
+        when(objectMapper.readValue(new byte[]{}, QuickQuoteResponse.class)).thenReturn(appResponse);
+
+        // When
+        var optResult = mapper.quickQuoteToKpiEvent(
+                new ContentCachingRequestWrapper(httpRequest),
+                new ContentCachingResponseWrapper(response),
+                Instant.now(),
+                "the-broker-id"
+        );
+
+        // Then
+        assertTrue(optResult.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenStatusIsNullInQuickQuoteResponse() throws IOException {
+        // Given
+        var httpRequest = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+
+        var appRequest = getQuickQuoteApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, QuickQuoteApplicationRequest.class)).thenReturn(appRequest);
+
+        QuickQuoteResponse appResponse = QuickQuoteResponse.builder().status(null).build();
+        when(objectMapper.readValue(new byte[]{}, QuickQuoteResponse.class)).thenReturn(appResponse);
+
+        // When
+        var optResult = mapper.quickQuoteToKpiEvent(
+                new ContentCachingRequestWrapper(httpRequest),
+                new ContentCachingResponseWrapper(response),
+                Instant.now(),
+                "the-broker-id"
+        );
+
+        // Then
+        assertTrue(optResult.isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenDecisionIsNullInQuickQuoteResponse() throws IOException {
+        // Given
+        var httpRequest = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+
+        var appRequest = getQuickQuoteApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, QuickQuoteApplicationRequest.class)).thenReturn(appRequest);
+
+        QuickQuoteResponse appResponse = QuickQuoteResponse.builder().status(null).build();
+        when(objectMapper.readValue(new byte[]{}, QuickQuoteResponse.class)).thenReturn(appResponse);
+
+        // When
+        var optResult = mapper.quickQuoteToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 Instant.now(),

--- a/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
+++ b/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
@@ -20,9 +20,10 @@ package com.selina.lending.messaging.publisher.mapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.selina.lending.internal.dto.ApplicationDto;
 import com.selina.lending.internal.dto.ApplicationResponse;
+import com.selina.lending.internal.dto.DIPApplicationRequest;
+import com.selina.lending.internal.dto.quote.QuickQuoteApplicationRequest;
 import com.selina.lending.internal.dto.quote.QuickQuoteResponse;
 import com.selina.lending.internal.mapper.MapperBase;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -65,12 +66,19 @@ class BrokerRequestEventMapperTest extends MapperBase {
         httpRequest.setRemoteAddr(ip);
         httpRequest.addHeader(REQUEST_ID_HEADER_NAME, foreignRequestId);
 
+        var appRequest = getDIPApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, DIPApplicationRequest.class)).thenReturn(appRequest);
+        String requestAsAString = "app_request_as_a_string";
+        when(objectMapper.writeValueAsString(appRequest)).thenReturn(requestAsAString);
+
         var httpResponseCode = 200;
         var response = new MockHttpServletResponse();
         response.setStatus(httpResponseCode);
 
         ApplicationResponse appResponse = ApplicationResponse.builder().application(getDIPApplicationDto()).build();
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);
+        String responseAsAString = "app_response_as_a_string";
+        when(objectMapper.writeValueAsString(appResponse)).thenReturn(responseAsAString);
 
         // When
         var optResult = mapper.dipToKpiEvent(
@@ -90,6 +98,8 @@ class BrokerRequestEventMapperTest extends MapperBase {
         assertThat(result.source()).isEqualTo(clientId);
         assertThat(result.uriPath()).isEqualTo(uriPath);
         assertThat(result.httpMethod()).isEqualTo(httpMethod);
+        assertThat(result.httpRequestBody()).isEqualTo(requestAsAString);
+        assertThat(result.httpResponseBody()).isEqualTo(responseAsAString);
         assertThat(result.httpResponseCode()).isEqualTo(httpResponseCode);
         assertThat(result.decision()).isEqualTo(appResponse.getApplication().getStatus());
         assertThat(result.started()).isEqualTo(started);
@@ -112,12 +122,19 @@ class BrokerRequestEventMapperTest extends MapperBase {
         httpRequest.setRemoteAddr(ip);
         httpRequest.addHeader(REQUEST_ID_HEADER_NAME, foreignRequestId);
 
+        var appRequest = getQuickQuoteApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, QuickQuoteApplicationRequest.class)).thenReturn(appRequest);
+        String requestAsAString = "app_request_as_a_string";
+        when(objectMapper.writeValueAsString(appRequest)).thenReturn(requestAsAString);
+
         var httpResponseCode = 200;
         var response = new MockHttpServletResponse();
         response.setStatus(httpResponseCode);
 
         var appResponse = QuickQuoteResponse.builder().externalApplicationId(EXTERNAL_APPLICATION_ID).status(DECISION).build();
         when(objectMapper.readValue(new byte[]{}, QuickQuoteResponse.class)).thenReturn(appResponse);
+        String responseAsAString = "app_response_as_a_string";
+        when(objectMapper.writeValueAsString(appResponse)).thenReturn(responseAsAString);
 
         // When
         var optResult = mapper.quickQuoteToKpiEvent(
@@ -137,6 +154,8 @@ class BrokerRequestEventMapperTest extends MapperBase {
         assertThat(result.source()).isEqualTo(clientId);
         assertThat(result.uriPath()).isEqualTo(uriPath);
         assertThat(result.httpMethod()).isEqualTo(httpMethod);
+        assertThat(result.httpRequestBody()).isEqualTo(requestAsAString);
+        assertThat(result.httpResponseBody()).isEqualTo(responseAsAString);
         assertThat(result.httpResponseCode()).isEqualTo(httpResponseCode);
         assertThat(result.decision()).isEqualTo(appResponse.getStatus());
         assertThat(result.started()).isEqualTo(started);
@@ -148,6 +167,9 @@ class BrokerRequestEventMapperTest extends MapperBase {
         // Given
         var httpRequest = new MockHttpServletRequest(); // without request-id header
         var response = new MockHttpServletResponse();
+
+        var appRequest = getDIPApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, DIPApplicationRequest.class)).thenReturn(appRequest);
 
         ApplicationResponse appResponse = ApplicationResponse.builder().application(getDIPApplicationDto()).build();
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);
@@ -172,6 +194,8 @@ class BrokerRequestEventMapperTest extends MapperBase {
         var httpRequest = new MockHttpServletRequest(); // without request-id header
         var response = new MockHttpServletResponse();
 
+        var appRequest = getDIPApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, DIPApplicationRequest.class)).thenReturn(appRequest);
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenThrow(new IOException("error"));
 
         // When
@@ -189,8 +213,11 @@ class BrokerRequestEventMapperTest extends MapperBase {
     @Test
     void shouldReturnEmptyWhenApplicationNotInResponse() throws IOException {
         // Given
-        var httpRequest = new MockHttpServletRequest(); // without request-id header
+        var httpRequest = new MockHttpServletRequest();
         var response = new MockHttpServletResponse();
+
+        var appRequest = getDIPApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, DIPApplicationRequest.class)).thenReturn(appRequest);
 
         ApplicationResponse appResponse = ApplicationResponse.builder().build();
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);
@@ -212,6 +239,9 @@ class BrokerRequestEventMapperTest extends MapperBase {
         // Given
         var httpRequest = new MockHttpServletRequest();
         var response = new MockHttpServletResponse();
+
+        var appRequest = getDIPApplicationRequestDto();
+        when(objectMapper.readValue(new byte[]{}, DIPApplicationRequest.class)).thenReturn(appRequest);
 
         var appResponse = ApplicationResponse.builder().application(ApplicationDto.builder().externalApplicationId(EXTERNAL_APPLICATION_ID).build()).build();
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);

--- a/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
+++ b/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
@@ -120,7 +120,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
         when(objectMapper.readValue(new byte[]{}, QuickQuoteResponse.class)).thenReturn(appResponse);
 
         // When
-        var optResult = mapper.dipToKpiEvent(
+        var optResult = mapper.quickQuoteToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 started,

--- a/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
+++ b/src/test/java/com/selina/lending/messaging/publisher/mapper/BrokerRequestEventMapperTest.java
@@ -73,7 +73,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);
 
         // When
-        var optResult = mapper.toBrokerRequestKpiEvent(
+        var optResult = mapper.dipToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 started,
@@ -120,7 +120,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
         when(objectMapper.readValue(new byte[]{}, QuickQuoteResponse.class)).thenReturn(appResponse);
 
         // When
-        var optResult = mapper.toBrokerRequestKpiEvent(
+        var optResult = mapper.dipToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 started,
@@ -153,7 +153,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);
 
         // When
-        var optResult = mapper.toBrokerRequestKpiEvent(
+        var optResult = mapper.dipToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 Instant.now(),
@@ -175,7 +175,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenThrow(new IOException("error"));
 
         // When
-        var optResult = mapper.toBrokerRequestKpiEvent(
+        var optResult = mapper.dipToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 Instant.now(),
@@ -196,7 +196,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);
 
         // When
-        var optResult = mapper.toBrokerRequestKpiEvent(
+        var optResult = mapper.dipToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 Instant.now(),
@@ -217,7 +217,7 @@ class BrokerRequestEventMapperTest extends MapperBase {
         when(objectMapper.readValue(new byte[]{}, ApplicationResponse.class)).thenReturn(appResponse);
 
         // When
-        var optResult = mapper.toBrokerRequestKpiEvent(
+        var optResult = mapper.dipToKpiEvent(
                 new ContentCachingRequestWrapper(httpRequest),
                 new ContentCachingResponseWrapper(response),
                 Instant.now(),


### PR DESCRIPTION
[LA-154] add request/response to the kpi event

[LA-154]: https://selina.atlassian.net/browse/LA-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


I refactored the mapper a little bit to open the possibility to parse requests/responses of different requests
Here I do value KISS over DRY as the main idea.
Actually, it is possible to separate QQ and DIP into different mapper beans, but I decided to leave them in a single bean as a compromise variant