### PR TITLE
GRO-1788: map missing fields missing quickquotecc

### DIFF
--- a/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
@@ -30,5 +30,4 @@ public interface OfferMapper {
 
     OfferDto mapToOfferDto(Offer offer);
     Offer mapToOffer(OfferDto offerDto);
-
 }

--- a/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
@@ -35,5 +35,5 @@ public interface OfferMapper {
 
     @Mapping(source = "offer.productCode", target = "code")
     @Mapping(source = "offer.product", target = "name")
-    ProductOfferDto mapToProductOffer(Offer offer);
+    ProductOfferDto mapToProductOfferDto(Offer offer);
 }

--- a/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
@@ -17,9 +17,7 @@
 
 package com.selina.lending.internal.mapper;
 
-import com.selina.lending.internal.dto.quote.ProductOfferDto;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -33,7 +31,4 @@ public interface OfferMapper {
     OfferDto mapToOfferDto(Offer offer);
     Offer mapToOffer(OfferDto offerDto);
 
-    @Mapping(source = "offer.productCode", target = "code")
-    @Mapping(source = "offer.product", target = "name")
-    ProductOfferDto mapToProductOfferDto(Offer offer);
 }

--- a/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/OfferMapper.java
@@ -17,7 +17,9 @@
 
 package com.selina.lending.internal.mapper;
 
+import com.selina.lending.internal.dto.quote.ProductOfferDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -30,4 +32,8 @@ public interface OfferMapper {
 
     OfferDto mapToOfferDto(Offer offer);
     Offer mapToOffer(OfferDto offerDto);
+
+    @Mapping(source = "offer.productCode", target = "code")
+    @Mapping(source = "offer.product", target = "name")
+    ProductOfferDto mapToProductOffer(Offer offer);
 }

--- a/src/main/java/com/selina/lending/internal/mapper/quotecc/OfferMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/quotecc/OfferMapper.java
@@ -1,0 +1,15 @@
+package com.selina.lending.internal.mapper.quotecc;
+
+import com.selina.lending.internal.dto.quote.ProductOfferDto;
+import com.selina.lending.internal.mapper.ErcMapper;
+import com.selina.lending.internal.service.application.domain.Offer;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(uses = {ErcMapper.class})
+public interface OfferMapper {
+
+    @Mapping(source = "offer.productCode", target = "code")
+    @Mapping(source = "offer.product", target = "name")
+    ProductOfferDto mapToProductOfferDto(Offer offer);
+}

--- a/src/main/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapper.java
@@ -2,11 +2,12 @@ package com.selina.lending.internal.mapper.quotecc;
 
 import com.selina.lending.internal.dto.quote.QuickQuoteResponse;
 import com.selina.lending.internal.mapper.ErcMapper;
+import com.selina.lending.internal.mapper.OfferMapper;
 import com.selina.lending.internal.service.application.domain.quotecc.QuickQuoteCCResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = {ErcMapper.class})
+@Mapper(uses = {ErcMapper.class, OfferMapper.class})
 public interface QuickQuoteCCResponseMapper {
 
     QuickQuoteCCResponseMapper INSTANCE = Mappers.getMapper(QuickQuoteCCResponseMapper.class);

--- a/src/main/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapper.java
@@ -1,12 +1,11 @@
 package com.selina.lending.internal.mapper.quotecc;
 
 import com.selina.lending.internal.dto.quote.QuickQuoteResponse;
-import com.selina.lending.internal.mapper.ErcMapper;
 import com.selina.lending.internal.service.application.domain.quotecc.QuickQuoteCCResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = {ErcMapper.class, OfferMapper.class})
+@Mapper(uses = {OfferMapper.class})
 public interface QuickQuoteCCResponseMapper {
 
     QuickQuoteCCResponseMapper INSTANCE = Mappers.getMapper(QuickQuoteCCResponseMapper.class);

--- a/src/main/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapper.java
@@ -2,7 +2,6 @@ package com.selina.lending.internal.mapper.quotecc;
 
 import com.selina.lending.internal.dto.quote.QuickQuoteResponse;
 import com.selina.lending.internal.mapper.ErcMapper;
-import com.selina.lending.internal.mapper.OfferMapper;
 import com.selina.lending.internal.service.application.domain.quotecc.QuickQuoteCCResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;

--- a/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
+++ b/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
@@ -142,6 +142,7 @@ public abstract class MapperBase {
     public static final String FROM_DATE = "2000-01-21";
     public static final String OFFER_ID = "offer123";
     public static final String PRODUCT_CODE = "All";
+    public static final String PRODUCT_NAME = "Homeowner loan, Status 0";
     public static final String EXPENDITURE_TYPE = "Utilities";
     public static final String EXTERNAL_APPLICATION_ID = "uniqueCaseID";
     public static final String RULE_OUTCOME = "Granted";
@@ -655,6 +656,7 @@ public abstract class MapperBase {
     protected Offer getOffer(String decision) {
         return Offer.builder().active(true).id(OFFER_ID).hasFee(true).productCode(PRODUCT_CODE)
                 .checklist(getChecklist())
+                .product(PRODUCT_NAME)
                 .ruleOutcomes(List.of(getRuleOutcome()))
                 .family(HOMEOWNER_LOAN)
                 .category(CATEGORY_STATUS_0)

--- a/src/test/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapperTest.java
+++ b/src/test/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapperTest.java
@@ -31,6 +31,8 @@ public class QuickQuoteCCResponseMapperTest extends MapperBase {
 
         assertThat(productOfferDto.getId(), equalTo(OFFER_ID));
         assertTrue(productOfferDto.getHasFee());
+        assertThat(productOfferDto.getCode(), equalTo(PRODUCT_CODE));
+        assertThat(productOfferDto.getName(), equalTo(PRODUCT_NAME));
         assertThat(productOfferDto.getFamily(), equalTo(HOMEOWNER_LOAN));
         assertThat(productOfferDto.getCategory(), equalTo(CATEGORY_STATUS_0));
         assertThat(productOfferDto.getErcPeriodYears(), equalTo(2));


### PR DESCRIPTION
**Description**

Map fields of a class to another with different names.

```
offers[].productCode -> offers[].code 
offers[].product -> offers[].name 
```


**Background Context**
In quickquotecc, lending api make a request to MW. 
MW response  is mapped to Lending API /quickquotecc response
However current Lending API /quickquotecc response have this fields with another names



**Additional Information**
Ticket: https://selina.atlassian.net/browse/GRO-1788