### PR TITLE
GRO-1789: Map missed field from MW response

### DIFF
--- a/src/main/java/com/selina/lending/internal/mapper/quotecc/OfferMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/quotecc/OfferMapper.java
@@ -11,5 +11,6 @@ public interface OfferMapper {
 
     @Mapping(source = "offer.productCode", target = "code")
     @Mapping(source = "offer.product", target = "name")
+    @Mapping(source = "offer.productFeeAddedToLoan", target = "hasProductFeeAddedToLoan")
     ProductOfferDto mapToProductOfferDto(Offer offer);
 }

--- a/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
+++ b/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
@@ -666,6 +666,7 @@ public abstract class MapperBase {
                 .ercShortCode(ERC_SHORT_CODE)
                 .maxErc(MAX_ERC)
                 .ercData(getErc())
+                .productFeeAddedToLoan(true)
                 .decision(decision)
                 .initialRate(INITIAL_RATE)
                 .initialTerm(INITIAL_TERM)

--- a/src/test/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapperTest.java
+++ b/src/test/java/com/selina/lending/internal/mapper/quotecc/QuickQuoteCCResponseMapperTest.java
@@ -49,6 +49,7 @@ public class QuickQuoteCCResponseMapperTest extends MapperBase {
         assertThat(productOfferDto.getProductFee(), equalTo(PRODUCT_FEE));
         assertThat(productOfferDto.getTotalAmountRepaid(), equalTo(TOTAL_AMOUNT_REPAID));
         assertThat(productOfferDto.getOfferBalance(), equalTo(OFFER_BALANCE));
+        assertTrue(productOfferDto.getHasProductFeeAddedToLoan());
 
 
         assertErcData(productOfferDto);


### PR DESCRIPTION
**Description**

Its misssing map one field of MW response to QuickQuoteCC Response

`offers[].productFeeAddedToLoan -> offers[].hasProductFeeAddedToLoan 
`

**Background Context**
In quickquotecc, lending api make a request to MW.
MW response is mapped to Lending API /quickquotecc response
However current Lending API /quickquotecc response have this field with another name

**Additional Information**
Ticket: https://selina.atlassian.net/browse/GRO-1789

