### PR TITLE
GRO-1585: validation for expectsFutureIncomeDecrease and reason

### DIFF
--- a/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
@@ -43,10 +43,10 @@ public class IncomeDto {
 
     public enum ExpectsFutureIncomeDecreaseReasons {
         REDUNDANCY("Redundancy"),
-        MATERNITYORPATERNITYLEAVE("Maternity or paternity leave"),
-        CHNAGEINEMPLOYMENT("Change in employment"),
-        MOVINGTOPARTTIMEWORK("Moving to part-time work"),
-        ECONOMICCONDITIONS("Economic conditions"),
+        MATERNITY_OR_PATERNITY_LEAVE("Maternity or paternity leave"),
+        CHNAGE_IN_EMPLOYMENT("Change in employment"),
+        MOVING_TO_PART_TIME_WORK("Moving to part-time work"),
+        ECONOMIC_CONDITIONS("Economic conditions"),
         OTHER("OTHER");
 
         final String value;

--- a/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
@@ -35,7 +35,7 @@ public class IncomeDto {
     List<IncomeItemDto> income;
     Boolean doesNotHaveAnyIncome;
     Boolean expectsFutureIncomeDecrease;
-    @Schema(implementation = ExpectsFutureIncomeDecreaseReasons.class, description = "the reason if  expectsFutureIncomeDecrease is true")
+    @Schema(implementation = ExpectsFutureIncomeDecreaseReasons.class, description = "the reason if expectsFutureIncomeDecrease is true")
     @EnumValue(enumClass = ExpectsFutureIncomeDecreaseReasons.class)
     String expectsFutureIncomeDecreaseReason;
     Double contractDayRateVerified;

--- a/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
@@ -21,17 +21,43 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import com.selina.lending.api.support.validator.Conditional;
+import com.selina.lending.api.support.validator.EnumValue;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
 
 @Builder
-@Value
+@Data
+@Conditional(selected = "expectsFutureIncomeDecrease", values = {"true"}, required = {"expectsFutureIncomeDecreaseReason"})
 public class IncomeDto {
     @Valid
     List<IncomeItemDto> income;
     Boolean doesNotHaveAnyIncome;
     Boolean expectsFutureIncomeDecrease;
+    @Schema(implementation = ExpectsFutureIncomeDecreaseReasons.class, description = "the reason if  expectsFutureIncomeDecrease is true")
+    @EnumValue(enumClass = ExpectsFutureIncomeDecreaseReasons.class)
     String expectsFutureIncomeDecreaseReason;
     Double contractDayRateVerified;
     Integer contractDaysWorkedWeeklyVerified;
+
+    public enum ExpectsFutureIncomeDecreaseReasons {
+        REDUNDANCY("Redundancy"),
+        MATERNITYORPATERNITYLEAVE("Maternity or paternity leave"),
+        CHNAGEINEMPLOYMENT("Change in employment"),
+        MOVINGTOPARTTIMEWORK("Moving to part-time work"),
+        ECONOMICCONDITIONS("Economic conditions"),
+        OTHER("OTHER");
+
+        final String value;
+
+        ExpectsFutureIncomeDecreaseReasons(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+    }
 }

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
@@ -637,6 +637,20 @@ class DIPControllerValidationTest extends MapperBase {
     }
 
     @Test
+    void shouldGiveValidationErrorWhenCreateDipApplicationAndSpecifyingIncorrectIncomeFrequency() throws Exception {
+        // Given
+        var dipApplicationRequest = getDIPApplicationRequestDto();
+        dipApplicationRequest.getApplicants().get(0).getIncome().getIncome().get(0).setFrequency("Unsupported value");
+
+        // When
+        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
+                        .contentType(APPLICATION_JSON))
+                // Then
+                .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income.income[0].frequency"))
+                .andExpect(jsonPath("$.violations[0].message").value("value is not valid"));
+    }
+
+    @Test
     void shouldGiveValidationErrorWhenCreateDipApplicationWithoutSpecifyingAllowedExpectsFutureIncomeDecreaseReason() throws Exception {
         // Given
         var dipApplicationRequest = getDIPApplicationRequestDto();
@@ -667,18 +681,5 @@ class DIPControllerValidationTest extends MapperBase {
                         .contentType(APPLICATION_JSON))
                 //Then
                 .andExpect(status().isOk());
-    }
-
-    @Test
-    void shouldGiveValidationErrorWhenCreateDipApplicationAndSpecifyingIncorrectIncomeFrequency() throws Exception {
-        // Given
-        var dipApplicationRequest = getDIPApplicationRequestDto();
-        dipApplicationRequest.getApplicants().get(0).getIncome().getIncome().get(0).setFrequency("Unsupported value");
-
-        // When
-        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
-                        .contentType(APPLICATION_JSON))
-                // Then                .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income.income[0].frequency"))
-                .andExpect(jsonPath("$.violations[0].message").value("value is not valid"));
     }
 }

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
@@ -635,4 +635,37 @@ class DIPControllerValidationTest extends MapperBase {
                 .andExpect(jsonPath("$.violations[1].field").value("applicants"))
                 .andExpect(jsonPath("$.violations[1].message").value("The field 'applicant2LivesWithApplicant1For3Years' is required for the second applicant"));
     }
+
+    @Test
+    void shouldGiveValidationErrorWhenCreateDipApplicationWithoutSpecifyingAllowedExpectsFutureIncomeDecreaseReason() throws Exception {
+        // Given
+        var dipApplicationRequest = getDIPApplicationRequestDto();
+        dipApplicationRequest.getApplicants().get(0).getIncome().setExpectsFutureIncomeDecrease(true);
+        dipApplicationRequest.getApplicants().get(0).getIncome().setExpectsFutureIncomeDecreaseReason("Unsupported value");
+
+        // When
+        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
+                        .contentType(APPLICATION_JSON))
+                //Then
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.title").value("Constraint Violation"))
+                .andExpect(jsonPath("$.violations", hasSize(1)))
+                .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income.expectsFutureIncomeDecreaseReason"))
+                .andExpect(jsonPath("$.violations[0].message").value("value is not valid"));
+    }
+
+    @Test
+    void shouldGiveNoValidationErrorWhenCreateDipApplicationSpecifyAllowedExpectsFutureIncomeDecreaseFalseButReasonSupplied() throws Exception {
+        //Given
+        var dipApplicationRequest = getDIPCCApplicationRequestDto();
+        dipApplicationRequest.getApplicants().get(0).getIncome().setExpectsFutureIncomeDecrease(false);
+        dipApplicationRequest.getApplicants().get(0).getIncome().setExpectsFutureIncomeDecreaseReason("Redundancy");
+
+        //When
+        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
+                        .contentType(APPLICATION_JSON))
+                //Then
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
@@ -670,6 +670,25 @@ class DIPControllerValidationTest extends MapperBase {
     }
 
     @Test
+    void shouldGiveValidationErrorWhenCreateDipApplicationHasExpectsFutureIncomeDecreaseTrueButNoReason() throws Exception {
+        // Given
+        var dipApplicationRequest = getDIPApplicationRequestDto();
+        dipApplicationRequest.getApplicants().get(0).getIncome().setExpectsFutureIncomeDecrease(true);
+        dipApplicationRequest.getApplicants().get(0).getIncome().setExpectsFutureIncomeDecreaseReason(null);
+
+        // When
+        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
+                        .contentType(APPLICATION_JSON))
+                //Then
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.title").value("Constraint Violation"))
+                .andExpect(jsonPath("$.violations", hasSize(1)))
+                .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income.expectsFutureIncomeDecreaseReason"))
+                .andExpect(jsonPath("$.violations[0].message").value("This field is required"));
+    }
+
+    @Test
     void shouldGiveNoValidationErrorWhenCreateDipApplicationSpecifyAllowedExpectsFutureIncomeDecreaseFalseButReasonSupplied() throws Exception {
         //Given
         var dipApplicationRequest = getDIPCCApplicationRequestDto();


### PR DESCRIPTION
#### Description
[GRO-1585](https://selina.atlassian.net/browse/GRO-1585)
Add conditional validation for expectsFutureIncomeDecreaseReason.
If expectsFutureIncomeDecrease is true then the expectsFutureIncomeDecreaseReason must be one of the following enum values provided.

#### Background Context
Integrate with Ocean Finance.

#### Additional Information



[GRO-1585]: https://selina.atlassian.net/browse/GRO-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ