### PR TITLE
GRO-1793: income list object must not be null

### DIFF
--- a/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/IncomeDto.java
@@ -20,6 +20,7 @@ package com.selina.lending.internal.dto;
 import java.util.List;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 import com.selina.lending.api.support.validator.Conditional;
 import com.selina.lending.api.support.validator.EnumValue;
@@ -32,6 +33,7 @@ import lombok.Data;
 @Conditional(selected = "expectsFutureIncomeDecrease", values = {"true"}, required = {"expectsFutureIncomeDecreaseReason"})
 public class IncomeDto {
     @Valid
+    @NotNull
     List<IncomeItemDto> income;
     Boolean doesNotHaveAnyIncome;
     Boolean expectsFutureIncomeDecrease;

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
@@ -701,4 +701,42 @@ class DIPControllerValidationTest extends MapperBase {
                 //Then
                 .andExpect(status().isOk());
     }
+
+    @Test
+    void shouldGiveValidationErrorWhenCreateDipApplicationWithoutSpecifyingMainIncome() throws Exception {
+        //Given
+        var dipApplicationRequest = getDIPApplicationRequestDto();
+        var applicant = dipApplicationRequest.getApplicants().get(0);
+        applicant.setIncome(null);
+
+        //When
+        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
+                        .contentType(APPLICATION_JSON))
+                //Then
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.title").value("Constraint Violation"))
+                .andExpect(jsonPath("$.violations", hasSize(1)))
+                .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income"))
+                .andExpect(jsonPath("$.violations[0].message").value("must not be null"));
+    }
+
+    @Test
+    void shouldGiveValidationErrorWhenCreateDipApplicationWhenSpecifyNullForIncomeItemsList() throws Exception {
+        //Given
+        var dipApplicationRequest = getDIPApplicationRequestDto();
+        var applicant = dipApplicationRequest.getApplicants().get(0);
+        applicant.getIncome().setIncome(null);
+
+        //When
+        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
+                        .contentType(APPLICATION_JSON))
+                //Then
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.title").value("Constraint Violation"))
+                .andExpect(jsonPath("$.violations", hasSize(1)))
+                .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income.income"))
+                .andExpect(jsonPath("$.violations[0].message").value("must not be null"));
+    }
 }

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
@@ -38,9 +38,11 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -738,5 +740,19 @@ class DIPControllerValidationTest extends MapperBase {
                 .andExpect(jsonPath("$.violations", hasSize(1)))
                 .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income.income"))
                 .andExpect(jsonPath("$.violations[0].message").value("must not be null"));
+    }
+
+    @Test
+    void shouldCreateDipApplicationWithoutSpecifiedAnyApplicantsIncomeItems() throws Exception {
+        //Given
+        var dipApplicationRequest = getDIPApplicationRequestDto();
+        var applicant = dipApplicationRequest.getApplicants().get(0);
+        applicant.getIncome().setIncome(emptyList());
+
+        //When
+        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
+                        .contentType(APPLICATION_JSON))
+                //Then
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
#### Description
[GRO-1793](https://selina.atlassian.net/browse/GRO-1793)

#### Background Context
While creating an application via the Lending API we can specify each applicant's income information. This income object must not be null.
Also, we have a subobject here with the same name which is a list of income we want to specify. This list might be empty, but the whole object can not be null, because the MW expects to get it even if the list doesn't have any income element inside.

```
],
      "income": {  // <<<<<<< must not be null
        "income": [   // <<<<<<< must not be null, but it can be an empty list
          {
            "type": "string",
            "amount": 0
          }
        ],
        "doesNotHaveAnyIncome": true,
        "expectsFutureIncomeDecrease": true,
        "expectsFutureIncomeDecreaseReason": "string",
        "contractDayRateVerified": 0,
        "contractDaysWorkedWeeklyVerified": 0
      },
```

#### Additional Information

[GRO-1793]: https://selina.atlassian.net/browse/GRO-1793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ