### PR TITLE
fix npe raised when offers comes as null

### DIFF
--- a/src/main/java/com/selina/lending/internal/enricher/ApplicationResponseEnricher.java
+++ b/src/main/java/com/selina/lending/internal/enricher/ApplicationResponseEnricher.java
@@ -21,10 +21,12 @@ public class ApplicationResponseEnricher {
 
     public void enrichQuickQuoteResponseWithProductOffersApplyUrl(QuickQuoteResponse response) {
         var offers = response.getOffers();
-        for (ProductOfferDto offer : offers) {
-            offer.setApplyUrl(
-                    this.quickQuoteProductOffersApplyUrlBuilder(response.getExternalApplicationId(), offer.getCode())
-            );
+        if (offers != null) {
+            for (ProductOfferDto offer : offers) {
+                offer.setApplyUrl(
+                        this.quickQuoteProductOffersApplyUrlBuilder(response.getExternalApplicationId(), offer.getCode())
+                );
+            }
         }
     }
 

--- a/src/test/java/com/selina/lending/internal/enricher/ApplicationResponseEnricherTest.java
+++ b/src/test/java/com/selina/lending/internal/enricher/ApplicationResponseEnricherTest.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @ExtendWith(MockitoExtension.class)
 public class ApplicationResponseEnricherTest {
@@ -58,5 +59,19 @@ public class ApplicationResponseEnricherTest {
 
         // then
         assertThat(response.getOffers().get(0).getApplyUrl(), equalTo(expected));
+    }
+
+    @Test
+    void enrichQuickQuoteResponseApplyUrlDoesNotOccurIfOffersEmpty() {
+        // Given
+        var externalApplicationId = UUID.randomUUID().toString();
+        var response = QuickQuoteResponse
+                .builder()
+                .externalApplicationId(externalApplicationId)
+                .offers(null)
+                .build();
+
+        // When/Then
+        assertDoesNotThrow(() -> enricher.enrichQuickQuoteResponseWithProductOffersApplyUrl(response));
     }
 }


### PR DESCRIPTION
#### Description
add conditional to check whether or not the offers list is null before enriching the response with applyUrl.

#### Background Context
Was breaking in production because sometimes the offers list would come back as null from decisioning.

