### PR TITLE
refactor(GRO-1838): include eligibility in response from selection an…

### DIFF
--- a/src/main/java/com/selina/lending/internal/dto/LendingConstants.java
+++ b/src/main/java/com/selina/lending/internal/dto/LendingConstants.java
@@ -23,6 +23,8 @@ public final class LendingConstants {
 
     public static final String CLIENT_ID_JWT_CLAIM_NAME = "clientId";
 
+    public static final String PARTNER_ACCOUNT_ID_JWT_CLAIM_NAME = "partnerAccountId";
+
     public static final String PRODUCT_CODE_ALL = "All";
 
     public static final String REQUEST_SOURCE = Source.LENDING_API.toString();

--- a/src/main/java/com/selina/lending/internal/dto/quote/ProductOfferDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/quote/ProductOfferDto.java
@@ -56,5 +56,6 @@ public class ProductOfferDto {
     String ercShortCode;
     Integer ercPeriodYears;
     String applyUrl;
+    Double eligibility;
     List<ErcDto> ercData;
 }

--- a/src/main/java/com/selina/lending/internal/mapper/quote/QuickQuoteApplicationResponseMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/quote/QuickQuoteApplicationResponseMapper.java
@@ -62,5 +62,6 @@ public interface QuickQuoteApplicationResponseMapper {
     @Mapping(source = "offer.decision", target = "decision")
     @Mapping(source = "offer.ercPeriodYears", target = "ercPeriodYears")
     @Mapping(source = "offer.ercData", target = "ercData")
+    @Mapping(source = "offer.eligibility", target = "eligibility")
     ProductOfferDto mapToProductOfferDto(Product product);
 }

--- a/src/main/java/com/selina/lending/internal/repository/SelectionServiceRepositoryImpl.java
+++ b/src/main/java/com/selina/lending/internal/repository/SelectionServiceRepositoryImpl.java
@@ -54,5 +54,10 @@ public class SelectionServiceRepositoryImpl implements SelectionServiceRepositor
         var source = Source.builder().name(LendingConstants.REQUEST_SOURCE).account(
                 SourceAccount.builder().name(tokenService.retrieveSourceAccount()).build()).build();
         application.setSource(source);
+
+        var partnerAccountId = tokenService.retrievePartnerAccountId();
+        if (partnerAccountId != null) {
+            application.setPartnerAccountId(partnerAccountId);
+        }
     }
 }

--- a/src/main/java/com/selina/lending/internal/service/TokenService.java
+++ b/src/main/java/com/selina/lending/internal/service/TokenService.java
@@ -20,4 +20,5 @@ package com.selina.lending.internal.service;
 public interface TokenService {
     String retrieveClientId();
     String retrieveSourceAccount();
+    String retrievePartnerAccountId();
 }

--- a/src/main/java/com/selina/lending/internal/service/TokenServiceImpl.java
+++ b/src/main/java/com/selina/lending/internal/service/TokenServiceImpl.java
@@ -36,6 +36,16 @@ public class TokenServiceImpl implements TokenService {
         return retrieveFromToken(LendingConstants.SOURCE_ACCOUNT_JWT_CLAIM_NAME);
     }
 
+    @Override
+    public String retrievePartnerAccountId() {
+        try {
+            return retrieveFromToken(LendingConstants.PARTNER_ACCOUNT_ID_JWT_CLAIM_NAME);
+        } catch (UnsupportedOperationException | NullPointerException | IllegalArgumentException exception) {
+            // request is not coming from a partner so can safely ignore
+            return null;
+        }
+    }
+
     private String retrieveFromToken(String property) {
         var authentication = SecurityContextHolder.getContext().getAuthentication();
         var jwt = (Jwt) authentication.getPrincipal();

--- a/src/main/java/com/selina/lending/internal/service/application/domain/Offer.java
+++ b/src/main/java/com/selina/lending/internal/service/application/domain/Offer.java
@@ -76,4 +76,5 @@ public class Offer {
     Integer term;
     Double ear;
     Boolean hasErc;
+    Double eligibility;
 }

--- a/src/main/java/com/selina/lending/internal/service/application/domain/quote/Application.java
+++ b/src/main/java/com/selina/lending/internal/service/application/domain/quote/Application.java
@@ -26,6 +26,7 @@ import lombok.Data;
 @Data
 public class Application {
     String externalApplicationId;
+    String partnerAccountId;
     Source source;
     List<Applicant> applicants;
     LoanInformation loanInformation;

--- a/src/main/java/com/selina/lending/internal/service/application/domain/quote/ProductOffer.java
+++ b/src/main/java/com/selina/lending/internal/service/application/domain/quote/ProductOffer.java
@@ -49,5 +49,6 @@ public class ProductOffer {
     String decision;
     Double maxErc;
     Integer ercPeriodYears;
+    Double eligibility;
     List<Erc> ercData;
 }

--- a/src/main/java/com/selina/lending/internal/service/application/domain/quotecf/QuickQuoteCFRequest.java
+++ b/src/main/java/com/selina/lending/internal/service/application/domain/quotecf/QuickQuoteCFRequest.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class QuickQuoteCFRequest {
     String externalApplicationId;
     String sourceAccount;
+    String partnerAccountId;
     List<Applicant> applicants;
     LoanInformation loanInformation;
     PropertyDetails propertyDetails;

--- a/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
+++ b/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
@@ -207,6 +207,8 @@ public abstract class MapperBase {
     protected static final Double ARRANGEMENT_FEE = 1000.00;
     protected static final String BROKER_SUBMITTER_EMAIL = "broker_submitter@email.co.uk";
 
+    public static final Double ELIGIBILITY = 80.1;
+
     static {
         try {
             MODIFIED_DATE = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2023-01-22 11:00:00");
@@ -699,6 +701,7 @@ public abstract class MapperBase {
                 .term(LOAN_TERM)
                 .ear(EAR)
                 .hasErc(true)
+                .eligibility(ELIGIBILITY)
                 .build();
     }
 
@@ -772,6 +775,7 @@ public abstract class MapperBase {
                 .ercPeriodYears(2)
                 .maxErc(MAX_ERC)
                 .ercData(getErc())
+                .eligibility(ELIGIBILITY)
                 .build();
     }
 

--- a/src/test/java/com/selina/lending/internal/mapper/quote/QuickQuoteApplicationResponseMapperTest.java
+++ b/src/test/java/com/selina/lending/internal/mapper/quote/QuickQuoteApplicationResponseMapperTest.java
@@ -62,6 +62,7 @@ class QuickQuoteApplicationResponseMapperTest extends MapperBase {
         assertThat(offer.getIsVariable(), equalTo(true));
         assertThat(offer.getLtvCap(), equalTo(LTV_CAP));
         assertThat(offer.getMaxErc(), equalTo(MAX_ERC));
+        assertThat(offer.getEligibility(), equalTo(ELIGIBILITY));
 
         assertErcData(offer);
     }

--- a/src/test/java/com/selina/lending/internal/mapper/quotecf/QuickQuoteCFResponseMapperTest.java
+++ b/src/test/java/com/selina/lending/internal/mapper/quotecf/QuickQuoteCFResponseMapperTest.java
@@ -55,6 +55,7 @@ public class QuickQuoteCFResponseMapperTest extends MapperBase {
         assertThat(productOfferDto.getTerm(), equalTo(LOAN_TERM));
         assertThat(productOfferDto.getEar(), equalTo(EAR));
         assertTrue(productOfferDto.getHasErc());
+        assertThat(productOfferDto.getEligibility(), equalTo(ELIGIBILITY));
 
 
         assertErcData(productOfferDto);

--- a/src/test/java/com/selina/lending/internal/repository/SelectionServiceRepositoryTest.java
+++ b/src/test/java/com/selina/lending/internal/repository/SelectionServiceRepositoryTest.java
@@ -66,10 +66,13 @@ class SelectionServiceRepositoryTest {
         //Given
         var externalApplicationId = UUID.randomUUID().toString();
         var sourceAccount = "Broker";
+        var partnerAccountId = "Partner";
+
         when(filterQuickQuoteApplicationRequest.getApplication()).thenReturn(application);
         when(selectionServiceApi.filterQuickQuote(any())).thenReturn(filteredQuickQuoteDecisionResponse);
         when(application.getExternalApplicationId()).thenReturn(externalApplicationId);
         when(tokenService.retrieveSourceAccount()).thenReturn(sourceAccount);
+        when(tokenService.retrievePartnerAccountId()).thenReturn(partnerAccountId);
 
         //When
         selectionServiceRepository.filter(filterQuickQuoteApplicationRequest);
@@ -77,5 +80,25 @@ class SelectionServiceRepositoryTest {
         //Then
         verify(selectionServiceApi, times(1)).filterQuickQuote(filterQuickQuoteApplicationRequest);
         verify(application, times(1)).setSource(any(Source.class));
+        verify(application, times(1)).setPartnerAccountId(any(String.class));
+    }
+
+    @Test
+    void filterShouldCallHttpClientNullPartnerAccountId() {
+        //Given
+        var externalApplicationId = UUID.randomUUID().toString();
+        var sourceAccount = "Broker";
+
+        when(filterQuickQuoteApplicationRequest.getApplication()).thenReturn(application);
+        when(selectionServiceApi.filterQuickQuote(any())).thenReturn(filteredQuickQuoteDecisionResponse);
+        when(application.getExternalApplicationId()).thenReturn(externalApplicationId);
+        when(tokenService.retrieveSourceAccount()).thenReturn(sourceAccount);
+        when(tokenService.retrievePartnerAccountId()).thenReturn(null);
+
+        //When
+        selectionServiceRepository.filter(filterQuickQuoteApplicationRequest);
+
+        //Then
+        verify(application, times(0)).setPartnerAccountId(any());
     }
 }


### PR DESCRIPTION
…d partnerAccountId in request

[GRO-1838](https://selina.atlassian.net/browse/GRO-1838)

#### Description
Include partnerAccountId in request to selection service which should send it to decisioning.
partnerAccountId taken from token which has the value for aggregators set in there by a hardcoded claim via keycloak mapper.
Response from selection service will include eligibility.

#### Background Context
Getting aggregators ready to use lending api.

#### Additional Information
Daniel's accompanying PR in selection service: [GRO-1839](https://github.com/Selina-Finance/ms-selection/pull/30)
