### PR TITLE
map offer propertyValueation to a Kafka event

### DIFF
--- a/src/main/java/com/selina/lending/internal/service/application/domain/Offer.java
+++ b/src/main/java/com/selina/lending/internal/service/application/domain/Offer.java
@@ -89,6 +89,7 @@ public class Offer {
     String decisionFraud;
     Double baseRateStressed;
     Double aprcStressed;
+    Double propertyValuation;
     Double initialRateMinimum;
     Double reversionMargin;
     Double reversionRateMinimum;

--- a/src/main/java/com/selina/lending/messaging/mapper/middleware/MiddlewareCreateApplicationEventMapper.java
+++ b/src/main/java/com/selina/lending/messaging/mapper/middleware/MiddlewareCreateApplicationEventMapper.java
@@ -93,6 +93,7 @@ public abstract class MiddlewareCreateApplicationEventMapper {
     @Mapping(target = "decisionFraud", source = "product.offer.decisionFraud")
     @Mapping(target = "baseRateStressed", source = "product.offer.baseRateStressed")
     @Mapping(target = "aprcStressed", source = "product.offer.aprcStressed")
+    @Mapping(target = "propertyValuation", source = "product.offer.propertyValuation")
     @Mapping(target = "initialRateMinimum", source = "product.offer.initialRateMinimum")
     @Mapping(target = "reversionMargin", source = "product.offer.reversionMargin")
     @Mapping(target = "reversionRateMinimum", source = "product.offer.reversionRateMinimum")

--- a/src/test/java/com/selina/lending/messaging/mapper/middleware/MiddlewareCreateApplicationEventMapperTest.java
+++ b/src/test/java/com/selina/lending/messaging/mapper/middleware/MiddlewareCreateApplicationEventMapperTest.java
@@ -183,6 +183,7 @@ public class MiddlewareCreateApplicationEventMapperTest extends MapperBase {
         assertThat(offer.getDecisionFraud(), equalTo(DECISION_FRAUD));
         assertThat(offer.getBaseRateStressed(), equalTo(BASE_RATE_STRESSED));
         assertThat(offer.getAprcStressed(), equalTo(APRC_STRESSED));
+        assertThat(offer.getPropertyValuation(), equalTo(PROPERTY_VALUATION));
         assertThat(offer.getInitialRateMinimum(), equalTo(INITIAL_RATE_MINIMUM));
         assertThat(offer.getReversionMargin(), equalTo(REVERSION_MARGIN));
         assertThat(offer.getReversionRateMinimum(), equalTo(REVERSION_RATE_MINIMUM));


### PR DESCRIPTION
#### Description
In the scope of the [PR-174](https://github.com/Selina-Finance/ms-lending-api/pull/174) I forgot to map the "propertyValuation" field.

#### Background Context

#### Additional Information
