### PR TITLE
GRO-2133: applicant's identifier is 1 for primaty applicants and is 2 for secondary

### DIFF
--- a/src/main/java/com/selina/lending/internal/enricher/MiddlewareRequestEnricher.java
+++ b/src/main/java/com/selina/lending/internal/enricher/MiddlewareRequestEnricher.java
@@ -105,6 +105,6 @@ public class MiddlewareRequestEnricher {
     }
 
     private void setIdentifier(Applicant applicant) {
-        applicant.setIdentifier(Boolean.TRUE.equals(applicant.getPrimaryApplicant()) ?  0 : 1);
+        applicant.setIdentifier(Boolean.TRUE.equals(applicant.getPrimaryApplicant()) ?  1 : 2);
     }
 }

--- a/src/test/java/com/selina/lending/internal/enricher/MiddlewareRequestEnricherTest.java
+++ b/src/test/java/com/selina/lending/internal/enricher/MiddlewareRequestEnricherTest.java
@@ -70,7 +70,7 @@ class MiddlewareRequestEnricherTest {
         //Then
         assertThat(request.getSourceAccount(), equalTo(SOURCE_ACCOUNT));
         assertThat(request.getSource(), equalTo(LendingConstants.REQUEST_SOURCE));
-        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(0));
+        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(1));
         assertThat(request.getIncludeCreditCommitment(), equalTo(true));
         assertThat(request.getProductCode(), equalTo(LendingConstants.PRODUCT_CODE_ALL));
         assertThat(request.getPropertyDetails().getIsApplicantResidence(), equalTo(false));
@@ -94,8 +94,8 @@ class MiddlewareRequestEnricherTest {
         //Then
         assertThat(request.getSourceAccount(), equalTo(SOURCE_ACCOUNT));
         assertThat(request.getSource(), equalTo(LendingConstants.REQUEST_SOURCE));
-        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(0));
-        assertThat(request.getApplicants().get(1).getIdentifier(), equalTo(1));
+        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(1));
+        assertThat(request.getApplicants().get(1).getIdentifier(), equalTo(2));
         assertThat(request.getIncludeCreditCommitment(), equalTo(false));
         assertThat(request.getProductCode(), equalTo(LendingConstants.PRODUCT_CODE_ALL));
         assertThat(request.getStageOverwrite(), equalTo(LendingConstants.STAGE_OVERWRITE));
@@ -160,8 +160,8 @@ class MiddlewareRequestEnricherTest {
 
         //Then
         assertThat(request.getRunDecisioning(), equalTo(true));
-        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(0));
-        assertThat(request.getApplicants().get(1).getIdentifier(), equalTo(1));
+        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(1));
+        assertThat(request.getApplicants().get(1).getIdentifier(), equalTo(2));
         assertThat(request.getPropertyDetails().getIsApplicantResidence(), equalTo(true));
     }
 
@@ -184,8 +184,8 @@ class MiddlewareRequestEnricherTest {
         //Then
         assertThat(request.getSourceAccount(), equalTo(SOURCE_ACCOUNT));
         assertThat(request.getSource(), equalTo(LendingConstants.REQUEST_SOURCE));
-        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(0));
-        assertThat(request.getApplicants().get(1).getIdentifier(), equalTo(1));
+        assertThat(request.getApplicants().get(0).getIdentifier(), equalTo(1));
+        assertThat(request.getApplicants().get(1).getIdentifier(), equalTo(2));
         assertThat(request.getIncludeCreditCommitment(), equalTo(false));
         assertThat(request.getProductCode(), equalTo(LendingConstants.PRODUCT_CODE_ALL));
         assertThat(request.getStageOverwrite(), equalTo(LendingConstants.STAGE_OVERWRITE));


### PR DESCRIPTION
[GRO-2133](https://selina.atlassian.net/browse/GRO-2133)

While the Lending API requests the MW to create DIP applications it should provide in a request body
* applicants[].identifier=1 (instead of 0) if the primaryApplicant=true
* applicants[].identifier=2 (instead of 1) if the primaryApplicant=false

because the MW [expects](https://github.com/Selina-Finance/ms-middleware-api/blob/main/middleware/credit_commitments/application_mapper.py#L54) only 1 and 2 values
![image](https://github.com/Selina-Finance/ms-lending-api/assets/19750652/91a35de3-85ff-49f9-8214-4cc03a51ed8f)




[GRO-2133]: https://selina.atlassian.net/browse/GRO-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ