### PR TITLE
chore(GRO-2167): fix validation bug for requested loan amount in requ…

### DIFF
--- a/generated/swagger-documentation/lending-api.json
+++ b/generated/swagger-documentation/lending-api.json
@@ -1337,9 +1337,9 @@
         "type":"object",
         "properties":{
           "requestedLoanAmount":{
-            "type":"integer",
+            "type":"number",
             "description":"the amount the applicant wishes to borrow (min 10000, max 1000000)",
-            "format":"int32"
+            "format":"double"
           },
           "requestedLoanTerm":{
             "type":"integer",
@@ -1796,9 +1796,9 @@
         "type":"object",
         "properties":{
           "requestedLoanAmount":{
-            "type":"integer",
+            "type":"number",
             "description":"the amount the applicant wishes to borrow (min 10000, max 1000000)",
-            "format":"int32"
+            "format":"double"
           },
           "requestedLoanTerm":{
             "type":"integer",

--- a/src/main/java/com/selina/lending/internal/dto/LoanInformationDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/LoanInformationDto.java
@@ -36,7 +36,7 @@ public class LoanInformationDto {
     @NotNull
     @Range(min = 10000, max = 1000000)
     @Schema(description = "the amount the applicant wishes to borrow (min 10000, max 1000000)")
-    private Integer requestedLoanAmount;
+    private Double requestedLoanAmount;
 
     @NotNull
     @Range(min = 5, max = 30)

--- a/src/main/java/com/selina/lending/internal/mapper/quote/QuickQuoteApplicationRequestMapper.java
+++ b/src/main/java/com/selina/lending/internal/mapper/quote/QuickQuoteApplicationRequestMapper.java
@@ -85,7 +85,7 @@ public class QuickQuoteApplicationRequestMapper {
     private static LoanInformation mapLoanInformation(LoanInformationDto loanInformationDto) {
         return loanInformationDto == null ? null : LoanInformation.builder().numberOfApplicants(
                 loanInformationDto.getNumberOfApplicants()).requestedLoanAmount(
-                Double.valueOf(loanInformationDto.getRequestedLoanAmount())).requestedLoanTerm(
+                loanInformationDto.getRequestedLoanAmount()).requestedLoanTerm(
                 loanInformationDto.getRequestedLoanTerm()).build();
     }
 

--- a/src/main/java/com/selina/lending/internal/service/application/domain/LoanInformation.java
+++ b/src/main/java/com/selina/lending/internal/service/application/domain/LoanInformation.java
@@ -27,7 +27,7 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Jacksonized
 public class LoanInformation {
-    Integer requestedLoanAmount;
+    Double requestedLoanAmount;
     int requestedLoanTerm;
     int numberOfApplicants;
     String loanPurpose;

--- a/src/test/java/com/selina/lending/api/support/validator/EnumValueImplTest.java
+++ b/src/test/java/com/selina/lending/api/support/validator/EnumValueImplTest.java
@@ -59,7 +59,7 @@ class EnumValueImplTest {
     void validateLoanInformation() {
         //Given
         var loanInformationDto = LoanInformationDto.builder()
-                .requestedLoanAmount(10000)
+                .requestedLoanAmount(10000.00)
                 .requestedLoanTerm(5)
                 .numberOfApplicants(1)
                 .loanPurpose(INVALID_VALUE)

--- a/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
+++ b/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
@@ -121,7 +121,7 @@ public abstract class MapperBase {
     public static final Double INCOME_AMOUNT = 15000.00;
     public static final String INCOME_TYPE = "Gross salary";
     public static final String LOAN_PURPOSE = "Home improvements";
-    public static final Integer LOAN_AMOUNT = 50000;
+    public static final Double LOAN_AMOUNT = 50000.00;
     public static final int LOAN_TERM = 5;
     public static final double ALLOCATION_AMOUNT = 50000;
     public static final Double AFFORDABILITY_DEFICIT = 2100.0;

--- a/src/test/java/com/selina/lending/internal/mapper/quotecf/QuickQuoteCFRequestMapperTest.java
+++ b/src/test/java/com/selina/lending/internal/mapper/quotecf/QuickQuoteCFRequestMapperTest.java
@@ -29,7 +29,7 @@ public class QuickQuoteCFRequestMapperTest extends MapperBase {
         assertThat(applicationRequest.getApplicants().get(0).getLastName(), equalTo(LAST_NAME));
         assertThat(applicationRequest.getApplicants().get(0).getIncome(), notNullValue());
         assertThat(applicationRequest.getApplicants().get(0).getIncome().getIncome().size(), equalTo(1));
-        assertThat(applicationRequest.getLoanInformation().getRequestedLoanAmount(), equalTo(REQUESTED_LOAN_AMOUNT.intValue()));
+        assertThat(applicationRequest.getLoanInformation().getRequestedLoanAmount(), equalTo(REQUESTED_LOAN_AMOUNT));
         assertThat(applicationRequest.getLoanInformation().getRequestedLoanTerm(), equalTo(LOAN_TERM));
         assertNull(applicationRequest.getSourceAccount());
 


### PR DESCRIPTION
…est due to integer type

#### Description
Changing the data type of the `loanInformation.requestedLoanAmount` from int to double due to errors that are caused when entering an amount that is larger than how much the int type can have.

If we leave it as Integer type then it will break when the the request is sent and cause a 400 before the validator gets to it. 

#### Background Context
Part of the bug work to fix before aggregator launch.

