### PR TITLE
refactor(GRO-2157): validation on addressdto date fields and new clas…

### DIFF
--- a/src/main/java/com/selina/lending/api/support/validator/MoveOutAfterMoveInDate.java
+++ b/src/main/java/com/selina/lending/api/support/validator/MoveOutAfterMoveInDate.java
@@ -1,0 +1,18 @@
+package com.selina.lending.api.support.validator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Documented
+@Constraint(validatedBy = MoveOutAfterMoveInDateImpl.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MoveOutAfterMoveInDate {
+
+    String message() default "toDate must exceed fromDate";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/src/main/java/com/selina/lending/api/support/validator/MoveOutAfterMoveInDateImpl.java
+++ b/src/main/java/com/selina/lending/api/support/validator/MoveOutAfterMoveInDateImpl.java
@@ -1,0 +1,25 @@
+package com.selina.lending.api.support.validator;
+
+
+import com.selina.lending.internal.dto.AddressDto;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MoveOutAfterMoveInDateImpl implements ConstraintValidator<MoveOutAfterMoveInDate, AddressDto> {
+
+    @Override
+    public boolean isValid(AddressDto value, ConstraintValidatorContext context) {
+        if (!value.getAddressType().equals("previous")) {
+            return true;
+        }
+
+        if (value.getToDate() == null || value.getFromDate() == null) {
+            return true;
+        }
+
+        return value.getToDate().isAfter(value.getFromDate());
+
+    }
+
+}

--- a/src/main/java/com/selina/lending/config/ObjectMapperConfiguration.java
+++ b/src/main/java/com/selina/lending/config/ObjectMapperConfiguration.java
@@ -17,6 +17,7 @@
 
 package com.selina.lending.config;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.problem.jackson.ProblemModule;
@@ -38,7 +39,8 @@ public class ObjectMapperConfiguration implements InitializingBean {
     public void afterPropertiesSet() {
         objectMapper.registerModules(
                 new ProblemModule(),
-                new ConstraintViolationProblemModule()
+                new ConstraintViolationProblemModule(),
+                new JavaTimeModule()
         );
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }

--- a/src/main/java/com/selina/lending/internal/dto/AddressDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/AddressDto.java
@@ -18,22 +18,29 @@
 package com.selina.lending.internal.dto;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.PastOrPresent;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.selina.lending.api.controller.SwaggerConstants;
 import com.selina.lending.api.support.validator.AtLeastOneNotBlank;
 import com.selina.lending.api.support.validator.Conditional;
 import com.selina.lending.api.support.validator.EnumValue;
+import com.selina.lending.api.support.validator.MoveOutAfterMoveInDate;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
 
 @NoArgsConstructor
 @SuperBuilder
 @Data
 @Conditional(selected = "addressType", values = {"previous"}, required = {"fromDate", "toDate"})
 @AtLeastOneNotBlank(fields = {"buildingName", "buildingNumber"})
+@MoveOutAfterMoveInDate
 public class AddressDto {
     @Schema(implementation = AddressType.class)
     @EnumValue(enumClass = AddressType.class)
@@ -65,13 +72,15 @@ public class AddressDto {
     @Size(min = 2, max = 60)
     String country;
 
-    @Pattern(regexp = SwaggerConstants.DATE_PATTERN, message = SwaggerConstants.DATE_INVALID_MESSAGE)
     @Schema(example = SwaggerConstants.EXAMPLE_DATE)
-    String fromDate;
+    @JsonFormat(pattern = SwaggerConstants.DATE_FORMAT)
+    @PastOrPresent
+    LocalDate fromDate;
 
-    @Pattern(regexp = SwaggerConstants.DATE_PATTERN, message = SwaggerConstants.DATE_INVALID_MESSAGE)
     @Schema(example = SwaggerConstants.EXAMPLE_DATE)
-    String toDate;
+    @JsonFormat(pattern = SwaggerConstants.DATE_FORMAT)
+    @PastOrPresent
+    LocalDate toDate;
 
     enum AddressType {
         CURRENT("current"),

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerCircuitBreakerTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerCircuitBreakerTest.java
@@ -50,7 +50,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = DIPController.class)
 class DIPControllerCircuitBreakerTest extends MapperBase {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
     @Autowired
     private MockMvc mockMvc;
     @MockBean

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
@@ -59,7 +59,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 class DIPControllerValidationTest extends MapperBase {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/selina/lending/api/support/validator/ConditionalImplTest.java
+++ b/src/test/java/com/selina/lending/api/support/validator/ConditionalImplTest.java
@@ -26,8 +26,11 @@ import javax.validation.Path;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.stream.Collectors;
 
+import static com.selina.lending.api.controller.SwaggerConstants.DATE_FORMAT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -80,8 +83,8 @@ class ConditionalImplTest {
                 .postcode(POSTCODE)
                 .buildingNumber(BUILDING_NUMBER)
                 .addressType(PREVIOUS_ADDRESS_TYPE)
-                .fromDate(FROM_DATE)
-                .toDate(TO_DATE)
+                .fromDate(LocalDate.parse(FROM_DATE, DateTimeFormatter.ofPattern(DATE_FORMAT)))
+                .toDate(LocalDate.parse(TO_DATE, DateTimeFormatter.ofPattern(DATE_FORMAT)))
                 .build();
 
         //When

--- a/src/test/java/com/selina/lending/api/support/validator/MoveOutAfterMoveInDateImplTest.java
+++ b/src/test/java/com/selina/lending/api/support/validator/MoveOutAfterMoveInDateImplTest.java
@@ -1,0 +1,97 @@
+package com.selina.lending.api.support.validator;
+
+import com.selina.lending.internal.dto.AddressDto;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MoveOutAfterMoveInDateImplTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidatorInstance() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void shouldReturnValidWhenFromDateIsNull() {
+        // Given
+        var toDate = LocalDate.parse("2000-01-01");
+
+        var addressDto = getAddressDto(null, toDate);
+
+        //When
+        var violations = validator.validate(addressDto);
+
+        //Then
+        assertThat(violations.stream().anyMatch(m -> m.getMessage().equals("toDate must exceed fromDate")), equalTo(false));
+    }
+
+    @Test
+    void shouldReturnValidWhenToDateIsNull() {
+        // Given
+        var fromDate = LocalDate.parse("2000-01-01");
+
+        var addressDto = getAddressDto(fromDate, null);
+
+        //When
+        var violations = validator.validate(addressDto);
+
+        //Then
+        assertThat(violations.stream().anyMatch(m -> m.getMessage().equals("toDate must exceed fromDate")), equalTo(false));
+
+    }
+
+    @Test
+    void shouldReturnInvalidWhenToDateBeforeFromDate() {
+        // Given
+        var fromDate = LocalDate.parse("2000-01-01");
+        var toDate = LocalDate.parse("1970-01-01");
+
+        var addressDto =  getAddressDto(fromDate, toDate);
+
+        //When
+        var violations = validator.validate(addressDto);
+
+        //Then
+        assertThat(violations.stream().anyMatch(m -> m.getMessage().equals("toDate must exceed fromDate")), equalTo(true));
+    }
+
+    @Test
+    void shouldReturnValidWhenToDateAfterFromDate() {
+        // Given
+        var fromDate = LocalDate.parse("1970-01-01");
+        var toDate = LocalDate.parse("2000-01-01");
+
+        var addressDto = getAddressDto(fromDate, toDate);
+
+        //When
+        var violations = validator.validate(addressDto);
+
+        //Then
+        assertThat(violations.stream().anyMatch(m -> m.getMessage().equals("toDate must exceed fromDate")), equalTo(false));
+    }
+
+    private AddressDto getAddressDto(LocalDate fromDate, LocalDate toDate) {
+        return AddressDto.builder()
+                .addressLine1("")
+                .addressType("previous")
+                .buildingNumber("")
+                .city("")
+                .postcode("")
+                .fromDate(fromDate)
+                .toDate(toDate)
+                .build();
+    }
+}

--- a/src/test/java/com/selina/lending/internal/mapper/AddressMapperTest.java
+++ b/src/test/java/com/selina/lending/internal/mapper/AddressMapperTest.java
@@ -19,6 +19,8 @@ package com.selina.lending.internal.mapper;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -67,6 +69,6 @@ class AddressMapperTest extends MapperBase {
         assertThat(addressDto.getUdprn(), equalTo(UDPRN));
         assertThat(addressDto.getPoBox(), equalTo(PO_BOX));
         assertThat(addressDto.getCounty(), equalTo(COUNTY));
-        assertThat(addressDto.getFromDate(), equalTo(FROM_DATE));
+        assertThat(addressDto.getFromDate(), equalTo(LocalDate.parse(FROM_DATE)));
     }
 }

--- a/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
+++ b/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
@@ -103,6 +103,7 @@ import com.selina.lending.internal.service.application.domain.quotecf.QuickQuote
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -136,17 +137,23 @@ public abstract class MapperBase {
     public static final String APPLICATION_ID = "123456789";
     public static final Date CREATED_DATE = Date.from(Instant.now());
     public static final String ADDRESS_LINE_1 = "address line 1";
+    public static final String PREVIOUS_ADDRESS_LINE_1 = "Evergreen Terrace";
     public static final String ADDRESS_LINE_2 = "address line 2";
     public static final String ADDRESS_TYPE = "current";
+    public static final String PREVIOUS_ADDRESS_TYPE = "previous";
     public static final String COUNTRY = "England";
     public static final String BUILDING_NUMBER = "10";
+    public static final String PREVIOUS_BUILDING_NUMBER = "742";
     public static final String CITY = "a city";
+    public static final String PREVIOUS_CITY = "Springfield";
     public static final String POSTCODE = "postcode";
     public static final int UDPRN = 1235;
     public static final String PO_BOX = "poBox";
     public static final String BUILDING_NAME = "building name";
     public static final String COUNTY = "county";
     public static final String FROM_DATE = "2000-01-21";
+    public static final String PREVIOUS_FROM_DATE = "2000-01-01";
+    public static final String PREVIOUS_TO_DATE = "2020-01-01";
     public static final String OFFER_ID = "offer123";
     public static final String PRODUCT_CODE = "All";
     public static final String PRODUCT_NAME = "Homeowner loan, Status 0";
@@ -414,7 +421,19 @@ public abstract class MapperBase {
                 .udprn(UDPRN)
                 .poBox(PO_BOX)
                 .county(COUNTY)
-                .fromDate(FROM_DATE)
+                .fromDate(LocalDate.parse(FROM_DATE))
+                .build();
+    }
+
+    protected AddressDto getPreviousAddressDto() {
+        return AddressDto.builder()
+                .addressLine1(PREVIOUS_ADDRESS_LINE_1)
+                .addressType(PREVIOUS_ADDRESS_TYPE)
+                .buildingNumber(PREVIOUS_BUILDING_NUMBER)
+                .city(PREVIOUS_CITY)
+                .postcode(POSTCODE)
+                .fromDate(LocalDate.parse(PREVIOUS_FROM_DATE))
+                .toDate(LocalDate.parse(PREVIOUS_TO_DATE))
                 .build();
     }
 

--- a/src/test/java/com/selina/lending/messaging/mapper/brokerrequest/BrokerRequestEventMapperTest.java
+++ b/src/test/java/com/selina/lending/messaging/mapper/brokerrequest/BrokerRequestEventMapperTest.java
@@ -18,6 +18,7 @@
 package com.selina.lending.messaging.mapper.brokerrequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.selina.lending.internal.dto.DIPApplicationResponse;
 import com.selina.lending.internal.mapper.MapperBase;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.when;
 class BrokerRequestEventMapperTest extends MapperBase {
     private static final String REQUEST_ID_HEADER_NAME = "x-selina-request-id";
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModules(new JavaTimeModule());
 
     @InjectMocks
     private BrokerRequestEventMapper mapper;

--- a/src/test/resources/__files/ms-lending-api/qq-application-request-bad-date-format.json
+++ b/src/test/resources/__files/ms-lending-api/qq-application-request-bad-date-format.json
@@ -1,0 +1,58 @@
+{
+  "externalApplicationId": "your_UniqueAppID_QQ",
+  "applicants": [
+    {
+      "emailAddress": "sara.abunaama@hotmail.com",
+      "mobileNumber": "07433121789",
+      "title": "Mrs.",
+      "firstName": "SARA",
+      "lastName": "ABUNAAMA",
+      "dateOfBirth": "1970-01-01",
+      "livedInCurrentAddressFor3Years": true,
+      "residentialStatus": "Owner",
+      "addresses": [
+        {
+          "addressType": "current",
+          "addressLine1": "NEWMARKET ROAD",
+          "city": "BRIGHTON",
+          "postcode": "BN2 3QF",
+          "buildingNumber": "58A",
+          "county": "United Kingdom",
+          "country": "UK",
+          "fromDate": "20-04-2022"
+        }
+      ],
+      "employment": {
+        "employmentStatus": "Employed",
+        "employmentType": "Permanent (full-time)",
+        "industry": "Technology"
+      },
+      "income": {
+        "income": [
+          {
+            "type": "Gross annual income",
+            "amount": 120000
+          }
+        ]
+      }
+    }
+  ],
+  "loanInformation": {
+    "numberOfApplicants": 1,
+    "requestedLoanAmount": 50000,
+    "requestedLoanTerm": 5,
+    "loanPurpose": "Debt consolidation"
+  },
+  "propertyDetails": {
+    "addressLine1": "HEDDFAN NORTH",
+    "city": "CARDIFF",
+    "postcode": "CF23 7EB",
+    "buildingNumber": "59",
+    "estimatedValue": 200000,
+    "numberOfPriorCharges": 1,
+    "priorCharges": {
+      "balanceOutstanding": 100000.0,
+      "monthlyPayment": 450
+    }
+  }
+}


### PR DESCRIPTION
…s validator for previous address dates

#### Description
Change the data type for `toDate` and `fromDate` in the `addressDto` from `String` to `LocalDate`. 

Add new class validator such that if the address is of type `previous` then the `fromDate` must be before the `toDate`. 

Add extra configuration to object mapper to account for `LocalDate`.

Add and amend unit tests. 

#### Background Context
Part of the work to fix the aggregator bugs before launch.