### PR TITLE
GRO-2248: additional validation of property details prior charges

### DIFF
--- a/src/main/java/com/selina/lending/api/support/validator/LessThanOrEqualTo.java
+++ b/src/main/java/com/selina/lending/api/support/validator/LessThanOrEqualTo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Selina Finance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.selina.lending.api.support.validator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {LessThanOrEqualToImpl.class})
+public @interface LessThanOrEqualTo {
+    String message() default "should be less than or equal to";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String comparisonValueFieldName();
+    String valueToCompareToFieldName();
+}

--- a/src/main/java/com/selina/lending/api/support/validator/LessThanOrEqualToImpl.java
+++ b/src/main/java/com/selina/lending/api/support/validator/LessThanOrEqualToImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Selina Finance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.selina.lending.api.support.validator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.beanutils.BeanUtils;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@Slf4j
+public class LessThanOrEqualToImpl implements ConstraintValidator<LessThanOrEqualTo, Object> {
+
+    private static final String ERROR_MESSAGE_FORMAT = "The '%s' must be less than or equal to the '%s'";
+
+    private String comparisonValueFieldName;
+    private String valueToCompareToFieldName;
+    private String errorMessage;
+
+    @Override
+    public void initialize(LessThanOrEqualTo lessThanOrEqualTo) {
+        comparisonValueFieldName = lessThanOrEqualTo.comparisonValueFieldName();
+        valueToCompareToFieldName = lessThanOrEqualTo.valueToCompareToFieldName();
+        errorMessage = ERROR_MESSAGE_FORMAT.formatted(comparisonValueFieldName, valueToCompareToFieldName);
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext context) {
+        try {
+            boolean isValid;
+            var comparisonValue = BeanUtils.getProperty(object, comparisonValueFieldName);
+            var valueToCompareTo = BeanUtils.getProperty(object, valueToCompareToFieldName);
+
+            if (comparisonValue == null || valueToCompareTo == null)
+                return true;
+
+            isValid = Double.compare(Double.parseDouble(comparisonValue), Double.parseDouble(valueToCompareTo)) <= 0;
+
+            if (!isValid) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(errorMessage).addPropertyNode(comparisonValueFieldName).addConstraintViolation();
+            }
+
+            return isValid;
+        } catch (Exception ex) {
+            log.error("Unexpected validation error class={}", object.getClass().getName(), ex);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/selina/lending/internal/dto/PriorChargesDto.java
+++ b/src/main/java/com/selina/lending/internal/dto/PriorChargesDto.java
@@ -17,22 +17,29 @@
 
 package com.selina.lending.internal.dto;
 
-import javax.validation.constraints.Pattern;
-
 import com.selina.lending.api.controller.SwaggerConstants;
-
+import com.selina.lending.api.support.validator.LessThanOrEqualTo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PositiveOrZero;
 
 @Builder
-@Value
+@Data
+@LessThanOrEqualTo(comparisonValueFieldName = "balanceConsolidated", valueToCompareToFieldName = "balanceOutstanding")
 public class PriorChargesDto {
+
+      @PositiveOrZero
       Double balanceConsolidated;
+      @PositiveOrZero
       Double balanceOutstanding;
+      @PositiveOrZero
       Double monthlyPayment;
       @Pattern(regexp = SwaggerConstants.DATE_PATTERN, message = SwaggerConstants.DATE_INVALID_MESSAGE)
       @Schema(example = SwaggerConstants.EXAMPLE_DATE)
       String priorChargesYoungestDate;
+      @PositiveOrZero
       Double otherDebtPayments;
 }

--- a/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
+++ b/src/test/java/com/selina/lending/internal/mapper/MapperBase.java
@@ -203,8 +203,8 @@ public abstract class MapperBase {
 
     public static final Boolean IS_APRC_HEADLINE = false;
     public static final Double REQUESTED_LOAN_AMOUNT = 50000.0;
-    public static final Double OUTSTANDING_BALANCE = 20000.0;
-    public static final Double BALANCE_CONSOLIDATED = 25000.0;
+    public static final Double OUTSTANDING_BALANCE = 25000.0;
+    public static final Double BALANCE_CONSOLIDATED = 20000.0;
     public static final Double OTHER_DEBT_PAYMENTS = 5000.0;
     public static final Double MAX_BALANCE_ESIS = 100000.0;
     public static final String ERC_PROFILE = "5%, 4%, 3%, 2%, 1%";

--- a/src/test/java/com/selina/lending/internal/repository/MiddlewareApplicationServiceRepositoryTest.java
+++ b/src/test/java/com/selina/lending/internal/repository/MiddlewareApplicationServiceRepositoryTest.java
@@ -60,7 +60,6 @@ class MiddlewareApplicationServiceRepositoryTest extends MapperBase {
         middlewareRepository = new MiddlewareApplicationServiceRepositoryImpl(middlewareApplicationServiceApi);
     }
 
-
     @Test
     void shouldCallHttpClientWhenGetApplicationIdByExternalApplicationIdInvoked() {
         //Given


### PR DESCRIPTION
#### Description
Creating the DIP application we can specify prior charges object
```
    "priorCharges": {
      "balanceConsolidated": 0,
      "balanceOutstanding": 0,
      "monthlyPayment": 0,
      "priorChargesYoungestDate": "2001-01-01",
      "otherDebtPayments": 0
    }
```

We need to provide additional validation that:
* all properties can’t be less than zero
* balanceConsolidated must be less or equal to balanceOutstanding

#### Background Context

#### Additional Information

Ticket [GRO-2248](https://selina.atlassian.net/browse/GRO-2248)


[GRO-2248]: https://selina.atlassian.net/browse/GRO-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ