### PR TITLE
chore(GRO-2313): Add method to enrich request with default fees values

### DIFF
--- a/src/main/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapper.java
+++ b/src/main/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapper.java
@@ -8,7 +8,6 @@ import com.selina.lending.service.TokenService;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
-import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -26,7 +25,6 @@ public abstract class MiddlewareQuickQuoteApplicationRequestMapper {
     private static final String SOURCE = "LendingAPI";
     private static final String APPLICATION_TYPE = "QuickQuote";
     private static final String HAS_GIVEN_CONSENT_FOR_MARKETING_COMMUNICATIONS = "false";
-    private static final boolean ADD_PRODUCT_FEES_TO_FACILITY = false;
 
     @Mapping(target = "sourceAccount", expression = "java(tokenService.retrieveSourceAccount())")
     @Mapping(target = "source", constant = SOURCE)
@@ -34,31 +32,9 @@ public abstract class MiddlewareQuickQuoteApplicationRequestMapper {
     @Mapping(target = "productCode", constant = PRODUCT_CODE)
     @Mapping(target = "applicants", source = "request.applicants")
     @Mapping(target = "hasGivenConsentForMarketingCommunications", constant = HAS_GIVEN_CONSENT_FOR_MARKETING_COMMUNICATIONS)
-    @Mapping(target = "fees", source = "fees", qualifiedByName = "setDefaultFeesValues")
+    @Mapping(target = "fees", source = "fees")
     @Mapping(target = "offers", source = "products")
     @Mapping(target = "partner", source = "request.partner")
     public abstract QuickQuoteRequest mapToQuickQuoteRequest(QuickQuoteApplicationRequest request,
                                                              List<Product> products, Fees fees);
-
-    @Named("setDefaultFeesValues")
-    Fees setDefaultFeesValues(Fees fees) {
-        return Fees.builder()
-                .isAddAdviceFeeToLoan(fees.getIsAddAdviceFeeToLoan())
-                .isAddArrangementFeeToLoan(fees.getIsAddArrangementFeeToLoan())
-                .isAddCommissionFeeToLoan(fees.getIsAddCommissionFeeToLoan())
-                .isAddThirdPartyFeeToLoan(fees.getIsAddThirdPartyFeeToLoan())
-                .isAddValuationFeeToLoan(fees.getIsAddValuationFeeToLoan())
-                .adviceFee(fees.getAdviceFee())
-                .arrangementFee(fees.getArrangementFee())
-                .commissionFee(fees.getCommissionFee())
-                .thirdPartyFee(fees.getThirdPartyFee())
-                .valuationFee(fees.getValuationFee())
-                .isAddProductFeesToFacility(ADD_PRODUCT_FEES_TO_FACILITY)
-                .intermediaryFeeAmount(fees.getIntermediaryFeeAmount())
-                .isAddIntermediaryFeeToLoan(fees.getIsAddIntermediaryFeeToLoan())
-                .addArrangementFeeSelina(fees.getAddArrangementFeeSelina())
-                .arrangementFeeDiscountSelina(fees.getArrangementFeeDiscountSelina())
-                .build();
-    }
-
 }

--- a/src/main/java/com/selina/lending/httpclient/middleware/dto/common/Fees.java
+++ b/src/main/java/com/selina/lending/httpclient/middleware/dto/common/Fees.java
@@ -47,5 +47,7 @@ public class Fees {
     @JsonProperty("addIntermediaryFeeToLoan")
     private Boolean isAddIntermediaryFeeToLoan;
     private Boolean addArrangementFeeSelina;
+    @JsonProperty("addArrangementFeeSelinaToLoan")
+    private Boolean isAddArrangementFeeSelinaToLoan;
     private Double arrangementFeeDiscountSelina;
 }

--- a/src/test/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapperTest.java
+++ b/src/test/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapperTest.java
@@ -37,6 +37,7 @@ class MiddlewareQuickQuoteApplicationRequestMapperTest extends MapperBase {
     private static final String LENDING_API_SOURCE = "LendingAPI";
     private static final String QUICK_QUOTE_APPLICATION_TYPE = "QuickQuote";
     private static final String QQ01_PRODUCT_CODE = "QQ01";
+    private static final Boolean ADD_ARRANGEMENT_FEE_SELINA_TO_LOAN = true;
 
     @MockBean
     private TokenService tokenService;
@@ -50,7 +51,11 @@ class MiddlewareQuickQuoteApplicationRequestMapperTest extends MapperBase {
         when(tokenService.retrieveSourceAccount()).thenReturn(SOURCE_ACCOUNT);
         QuickQuoteApplicationRequest quickQuoteApplicationRequest = getQuickQuoteApplicationRequestDto();
         List<Product> products = List.of(getProduct());
-        Fees fees = Fees.builder().arrangementFeeDiscountSelina(ARRANGEMENT_FEE_DISCOUNT_SELINA).addArrangementFeeSelina(true).build();
+        Fees fees = Fees.builder()
+                .arrangementFeeDiscountSelina(ARRANGEMENT_FEE_DISCOUNT_SELINA)
+                .addArrangementFeeSelina(true)
+                .isAddArrangementFeeSelinaToLoan(ADD_ARRANGEMENT_FEE_SELINA_TO_LOAN)
+                .build();
 
         //When
         QuickQuoteRequest middlewareCreateApplicationEvent =
@@ -65,7 +70,7 @@ class MiddlewareQuickQuoteApplicationRequestMapperTest extends MapperBase {
         assertThat(middlewareCreateApplicationEvent.getHasGivenConsentForMarketingCommunications(), equalTo(false));
 
         assertApplicants(middlewareCreateApplicationEvent.getApplicants());
-        assertFees(middlewareCreateApplicationEvent.getFees());
+        assertFees(fees, middlewareCreateApplicationEvent.getFees());
         assertLead(middlewareCreateApplicationEvent.getLead());
         assertLoanInformation(middlewareCreateApplicationEvent.getLoanInformation());
         assertPropertyDetails(middlewareCreateApplicationEvent.getPropertyDetails());
@@ -141,14 +146,23 @@ class MiddlewareQuickQuoteApplicationRequestMapperTest extends MapperBase {
         assertThat(income.getAmount(), equalTo(INCOME_AMOUNT));
     }
 
-    private void assertFees(Fees fees) {
-        Fees expectedFees = Fees.builder()
-                .isAddProductFeesToFacility(false)
-                .addArrangementFeeSelina(true)
-                .arrangementFeeDiscountSelina(ARRANGEMENT_FEE_DISCOUNT_SELINA)
-                .build();
-
-        assertThat(fees, equalTo(expectedFees));
+    private void assertFees(Fees originalFees, Fees actualFees) {
+        assertThat(actualFees.getIsAddAdviceFeeToLoan(), equalTo(originalFees.getIsAddAdviceFeeToLoan()));
+        assertThat(actualFees.getIsAddArrangementFeeToLoan(), equalTo(originalFees.getIsAddArrangementFeeToLoan()));
+        assertThat(actualFees.getIsAddCommissionFeeToLoan(), equalTo(originalFees.getIsAddCommissionFeeToLoan()));
+        assertThat(actualFees.getIsAddThirdPartyFeeToLoan(), equalTo(originalFees.getIsAddThirdPartyFeeToLoan()));
+        assertThat(actualFees.getIsAddValuationFeeToLoan(), equalTo(originalFees.getIsAddValuationFeeToLoan()));
+        assertThat(actualFees.getAdviceFee(), equalTo(originalFees.getAdviceFee()));
+        assertThat(actualFees.getArrangementFee(), equalTo(originalFees.getArrangementFee()));
+        assertThat(actualFees.getCommissionFee(), equalTo(originalFees.getCommissionFee()));
+        assertThat(actualFees.getThirdPartyFee(), equalTo(originalFees.getThirdPartyFee()));
+        assertThat(actualFees.getValuationFee(), equalTo(originalFees.getValuationFee()));
+        assertThat(actualFees.getIsAddProductFeesToFacility(), equalTo(originalFees.getIsAddProductFeesToFacility()));
+        assertThat(actualFees.getIntermediaryFeeAmount(), equalTo(originalFees.getIntermediaryFeeAmount()));
+        assertThat(actualFees.getIsAddIntermediaryFeeToLoan(), equalTo(originalFees.getIsAddIntermediaryFeeToLoan()));
+        assertThat(actualFees.getAddArrangementFeeSelina(), equalTo(originalFees.getAddArrangementFeeSelina()));
+        assertThat(actualFees.getIsAddArrangementFeeSelinaToLoan(), equalTo(originalFees.getIsAddArrangementFeeSelinaToLoan()));
+        assertThat(actualFees.getArrangementFeeDiscountSelina(), equalTo(originalFees.getArrangementFeeDiscountSelina()));
     }
 
     private void assertFeesWithAllOtherFees(Fees fees) {


### PR DESCRIPTION
#### Description

Title says basically all. We need to enrich the requests to decision and the Middleware save with more fields with default values.

#### Background Context

#### Additional Information

Before this is merged, another piece of work on ms-selection needs to be merged first to add the missing field `addArrangementFeeSelinaToLoan` and start sending to decision-v2.

---
