### PR TITLE
GRO-2388: set each offer's isAprcHeadline=true while creating QQ for the ClearScore only

### DIFF
--- a/src/main/java/com/selina/lending/api/controller/QuickQuoteController.java
+++ b/src/main/java/com/selina/lending/api/controller/QuickQuoteController.java
@@ -97,6 +97,7 @@ public class QuickQuoteController implements QuickQuoteOperations {
         var quickQuoteResponse = QuickQuoteApplicationResponseMapper.INSTANCE.mapToQuickQuoteResponse(filteredQuickQuoteDecisionResponse);
         applicationResponseEnricher.enrichQuickQuoteResponseWithExternalApplicationId(quickQuoteResponse, quickQuoteApplicationRequest.getExternalApplicationId());
         applicationResponseEnricher.enrichQuickQuoteResponseWithProductOffersApplyUrl(quickQuoteResponse);
+        applicationResponseEnricher.turnIsAprcHeadlineToTrueForEachOfferForClearScoreClientOnly(quickQuoteResponse);
         return quickQuoteResponse;
     }
 }

--- a/src/main/java/com/selina/lending/service/enricher/ApplicationResponseEnricher.java
+++ b/src/main/java/com/selina/lending/service/enricher/ApplicationResponseEnricher.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 @Slf4j
 public class ApplicationResponseEnricher {
 
+    private static final String CLEARSCORE_CLIENT_ID = "clearscore";
     private final String quickQuoteBaseUrl;
     private final TokenService tokenService;
 
@@ -25,6 +26,16 @@ public class ApplicationResponseEnricher {
 
     public void enrichQuickQuoteResponseWithExternalApplicationId(QuickQuoteResponse response, String externalApplicationId) {
         response.setExternalApplicationId(externalApplicationId);
+    }
+
+    public void turnIsAprcHeadlineToTrueForEachOfferForClearScoreClientOnly(QuickQuoteResponse response) {
+        String clientId = tokenService.retrieveClientId();
+        if (CLEARSCORE_CLIENT_ID.equalsIgnoreCase(clientId)) {
+            var offers = response.getOffers();
+            if (offers != null) {
+                offers.forEach(offer -> offer.setIsAprcHeadline(true));
+            }
+        }
     }
 
     public void enrichQuickQuoteResponseWithProductOffersApplyUrl(QuickQuoteResponse response) {
@@ -49,5 +60,4 @@ public class ApplicationResponseEnricher {
                 .build()
                 .toString();
     }
-
 }

--- a/src/test/java/com/selina/lending/api/controller/QuickQuoteControllerTest.java
+++ b/src/test/java/com/selina/lending/api/controller/QuickQuoteControllerTest.java
@@ -111,6 +111,7 @@ class QuickQuoteControllerTest {
         assertThat(Objects.requireNonNull(response.getBody()).getOffers(), not(empty()));
         assertOffersApplyUrlHasExpectedFormat(Objects.requireNonNull(response.getBody()).getOffers());
         verify(filterApplicationService, times(1)).filter(quickQuoteApplicationRequest);
+        verify(applicationResponseEnricher, times(1)).turnIsAprcHeadlineToTrueForEachOfferForClearScoreClientOnly(response.getBody());
     }
 
     @Test

--- a/src/test/java/com/selina/lending/service/enricher/ApplicationResponseEnricherTest.java
+++ b/src/test/java/com/selina/lending/service/enricher/ApplicationResponseEnricherTest.java
@@ -15,6 +15,9 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.Every.everyItem;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +46,38 @@ class ApplicationResponseEnricherTest {
 
         // then
         assertThat(response.getExternalApplicationId(), equalTo(id));
+    }
+
+    @Test
+    void whenClientIdIsClearScoreThenSetIsAprcHeadlineToTrueForEachOffer() {
+        var response = QuickQuoteResponse.builder()
+                .offers(List.of(
+                        ProductOfferDto.builder().isAprcHeadline(false).build(),
+                        ProductOfferDto.builder().isAprcHeadline(false).build()
+                ))
+                .build();
+
+        when(tokenService.retrieveClientId()).thenReturn("clearscore");
+
+        enricher.turnIsAprcHeadlineToTrueForEachOfferForClearScoreClientOnly(response);
+
+        assertThat(response.getOffers(), everyItem(hasProperty("isAprcHeadline", is(true))));
+    }
+
+    @Test
+    void whenClientIdIsClearScoreAndOffersIsNullThenDoNotSetIsAprcHeadlineToTrueForEachOffer() {
+        var response = QuickQuoteResponse.builder()
+                .offers(List.of(
+                        ProductOfferDto.builder().isAprcHeadline(false).build(),
+                        ProductOfferDto.builder().isAprcHeadline(false).build()
+                ))
+                .build();
+
+        when(tokenService.retrieveClientId()).thenReturn("monevo");
+
+        enricher.turnIsAprcHeadlineToTrueForEachOfferForClearScoreClientOnly(response);
+
+        assertThat(response.getOffers(), everyItem(hasProperty("isAprcHeadline", is(false))));
     }
 
     @Test


### PR DESCRIPTION
[GRO-2388](https://selina.atlassian.net/browse/GRO-2388)

We need this hack only for ClearScore because they provide estimatedValue in response, but because of the hack in the decisioning service (that returns only the lovest LTV offers) the final response is not real, so it’s like isAprcHeadline=true, but we provide isAprcHeadline=false.

So, until we have the dynamic pricing released we need this hack to be working.

[GRO-2388]: https://selina.atlassian.net/browse/GRO-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ