### PR TITLE
GRO-2371: Allow aggregators to provide incomes on a weekly frequency

### DIFF
--- a/src/main/java/com/selina/lending/api/dto/common/IncomeItemDto.java
+++ b/src/main/java/com/selina/lending/api/dto/common/IncomeItemDto.java
@@ -44,8 +44,8 @@ public class IncomeItemDto {
     @Schema(example = SwaggerConstants.EXAMPLE_DATE)
     private String incomeDate;
     private String relatedYear;
-    @Schema(implementation = frequency.class)
-    @EnumValue(enumClass = frequency.class)
+    @Schema(implementation = Frequency.class)
+    @EnumValue(enumClass = Frequency.class)
     private String frequency;
     private Double contractDaysWorkedWeeklyReported;
     private Double contractDayRateReported;
@@ -96,14 +96,14 @@ public class IncomeItemDto {
         }
     }
 
-    enum frequency {
+    enum Frequency {
+        WEEKLY("Weekly"),
         MONTHLY("Monthly"),
         ANNUALLY("Annually");
 
-
         private final String value;
 
-        frequency(String value) {
+        Frequency(String value) {
             this.value = value;
         }
 


### PR DESCRIPTION
[GRO-2371](https://selina.atlassian.net/browse/GRO-2371)

Current

Aggregator customers using the /quickquote endpoint can specify incomes as being Monthly, or Annually in frequency
![image](https://github.com/Selina-Finance/ms-lending-api/assets/19750652/c5b211b6-6b67-4c28-98c8-b2f02668ceee)



Desired

Data from Monevo shows that a fair proportion of customers (10%) enter their data as having Weekly frequency

Hence, we would like the API to be able to accept and accurately process incomes with a weekly frequency

[GRO-2371]: https://selina.atlassian.net/browse/GRO-2371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ