### PR TITLE
Gro 2371 delete income frequency field

### DIFF
--- a/src/main/java/com/selina/lending/api/dto/common/IncomeItemDto.java
+++ b/src/main/java/com/selina/lending/api/dto/common/IncomeItemDto.java
@@ -29,8 +29,11 @@ import javax.validation.constraints.Pattern;
 @Builder
 @Data
 public class IncomeItemDto {
+
+    @Schema(description = "Amount of annual income")
     @NotNull
     private Double amount;
+
     @NotNull
     @Schema(implementation = IncomeType.class)
     @EnumValue(enumClass = IncomeType.class)
@@ -43,10 +46,9 @@ public class IncomeItemDto {
     @Pattern(regexp = SwaggerConstants.DATE_PATTERN, message = SwaggerConstants.DATE_INVALID_MESSAGE)
     @Schema(example = SwaggerConstants.EXAMPLE_DATE)
     private String incomeDate;
+
     private String relatedYear;
-    @Schema(implementation = Frequency.class)
-    @EnumValue(enumClass = Frequency.class)
-    private String frequency;
+
     private Double contractDaysWorkedWeeklyReported;
     private Double contractDayRateReported;
 
@@ -94,23 +96,5 @@ public class IncomeItemDto {
         public String toString() {
             return this.value;
         }
-    }
-
-    enum Frequency {
-        WEEKLY("Weekly"),
-        MONTHLY("Monthly"),
-        ANNUALLY("Annually");
-
-        private final String value;
-
-        Frequency(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String toString() {
-            return this.value;
-        }
-
     }
 }

--- a/src/main/java/com/selina/lending/httpclient/middleware/dto/common/Income.java
+++ b/src/main/java/com/selina/lending/httpclient/middleware/dto/common/Income.java
@@ -33,7 +33,6 @@ public class Income {
     Double amountVerified;
     String incomeDate;
     String relatedYear;
-    String frequency;
     Double contractDaysWorkedWeeklyReported;
     Double contractDayRateReported;
 }

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerValidationTest.java
@@ -896,20 +896,6 @@ class DIPControllerValidationTest extends MapperBase {
     }
 
     @Test
-    void shouldGiveValidationErrorWhenCreateDipApplicationAndSpecifyingIncorrectIncomeFrequency() throws Exception {
-        // Given
-        var dipApplicationRequest = getDIPApplicationRequestDto();
-        dipApplicationRequest.getApplicants().get(0).getIncome().getIncome().get(0).setFrequency("Unsupported value");
-
-        // When
-        mockMvc.perform(post("/application/dip").with(csrf()).content(objectMapper.writeValueAsString(dipApplicationRequest))
-                        .contentType(APPLICATION_JSON))
-                // Then
-                .andExpect(jsonPath("$.violations[0].field").value("applicants[0].income.income[0].frequency"))
-                .andExpect(jsonPath("$.violations[0].message").value("value is not valid"));
-    }
-
-    @Test
     void shouldGiveValidationErrorWhenCreateDipApplicationWithoutSpecifyingAllowedExpectsFutureIncomeDecreaseReason() throws Exception {
         // Given
         var dipApplicationRequest = getDIPApplicationRequestDto();


### PR DESCRIPTION
[GRO-2371](https://selina.atlassian.net/browse/GRO-2371)
Since the income.frequency is not used anywhere it should be deleted from the API


[GRO-2371]: https://selina.atlassian.net/browse/GRO-2371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ