### PR TITLE
GRO-2471: Disable CSRF protection

### DIFF
--- a/src/main/java/com/selina/lending/config/security/SecurityConfig.java
+++ b/src/main/java/com/selina/lending/config/security/SecurityConfig.java
@@ -43,9 +43,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf()
-                .ignoringAntMatchers(ACTUATOR_URL + "/**")
-                .ignoringAntMatchers(LOGIN_URL)
-                .and()
+                .disable()
                 .cors()
                 .and()
                 .exceptionHandling()

--- a/src/test/java/com/selina/lending/api/controller/DIPControllerCircuitBreakerTest.java
+++ b/src/test/java/com/selina/lending/api/controller/DIPControllerCircuitBreakerTest.java
@@ -29,7 +29,8 @@ import feign.Request;
 import feign.RequestTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -40,14 +41,14 @@ import java.util.UUID;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WithMockUser
-@WebMvcTest(value = DIPController.class)
+@AutoConfigureMockMvc
+@SpringBootTest
 class DIPControllerCircuitBreakerTest extends MapperBase {
 
     @Autowired
@@ -85,7 +86,7 @@ class DIPControllerCircuitBreakerTest extends MapperBase {
                 new RemoteResourceProblemException());
 
         //When
-        mockMvc.perform(post("/application/dipcc").with(csrf())
+        mockMvc.perform(post("/application/dipcc")
                         .content(objectMapper.writeValueAsString(requestDto))
                         .contentType(APPLICATION_JSON))
                 //Then
@@ -103,7 +104,7 @@ class DIPControllerCircuitBreakerTest extends MapperBase {
                 DIPCCApplicationRequestMapper.INSTANCE.mapToApplicationRequest(requestDto));
 
         //When
-        mockMvc.perform(put("/application/" + dipId + "/dipcc").with(csrf())
+        mockMvc.perform(put("/application/" + dipId + "/dipcc")
                         .content(jsonRequestDto)
                         .contentType(APPLICATION_JSON))
                 //Then

--- a/src/test/java/com/selina/lending/api/controller/QuickQuoteControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/QuickQuoteControllerValidationTest.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -89,7 +88,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
                     .build());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -113,7 +112,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -131,7 +130,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -148,7 +147,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -171,7 +170,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -185,7 +184,6 @@ class QuickQuoteControllerValidationTest extends MapperBase {
                     .andExpect(jsonPath("$.violations[1].message").value("should be equal to applicants size"));
         }
 
-
         @Test
         void whenCreateApplicationWithNullApplicantsThenReturnBadRequest() throws Exception {
             //Given
@@ -195,7 +193,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -215,7 +213,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -232,7 +230,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -249,7 +247,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -273,7 +271,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -292,7 +290,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -311,7 +309,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -330,7 +328,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -353,7 +351,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -376,7 +374,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -397,7 +395,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -406,6 +404,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             verify(filterApplicationService, times(1)).filter(request);
         }
 
+        @Test
         void whenCreateQQApplicationWithOneApplicantAndLoanInformationNumberOfApplicantsIsOneThenReturnSuccess() throws Exception {
             //Given
             var request = getQuickQuoteApplicationRequestDto();
@@ -413,7 +412,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -429,7 +428,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getApplicants().get(0).setMobileNumber("012345AB90");
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -450,7 +449,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -471,7 +470,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -497,7 +496,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -516,7 +515,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getApplicants().get(0).setMobileNumber("012345AB90");
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -535,7 +534,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getApplicants().get(0).setMobileNumber("");
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     // Then
@@ -556,7 +555,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -580,7 +579,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -603,7 +602,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -622,7 +621,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -637,7 +636,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getPropertyDetails().setEstimatedValue(49_999.0);
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -655,7 +654,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getPropertyDetails().setEstimatedValue(100_000_000.01);
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -673,7 +672,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -688,7 +687,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -702,7 +701,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -720,7 +719,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getApplicants().get(0).getAddresses().get(0).setFromDate(LocalDate.parse("9999-12-25"));
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -741,7 +740,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getApplicants().get(0).setAddresses(List.of(getAddressDto(), previousAddress));
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -762,7 +761,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getApplicants().get(0).setAddresses(List.of(getAddressDto(), previousAddress));
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -781,7 +780,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             when(createApplicationService.createQuickQuoteCFApplication(any(QuickQuoteCFRequest.class))).thenReturn(getQuickQuoteCFResponse());
 
             //When
-            mockMvc.perform(post("/application/quickquotecf").with(csrf())
+            mockMvc.perform(post("/application/quickquotecf")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -802,7 +801,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
             request.getApplicants().get(0).setAddresses(List.of(getAddressDto(), previousAddress));
 
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(APPLICATION_JSON))
                     //Then
@@ -817,7 +816,7 @@ class QuickQuoteControllerValidationTest extends MapperBase {
         @Test
         void whenCreateApplicationWithPreviousAddressFromDateNotCorrectFormatThenBadRequest() throws Exception {
             //When
-            mockMvc.perform(post("/application/quickquote").with(csrf())
+            mockMvc.perform(post("/application/quickquote")
                             .content(Files.readString(getQQApplicationBadDateFormatRequest))
                             .contentType(APPLICATION_JSON))
                     //Then

--- a/src/test/java/com/selina/lending/api/controller/auth/AuthControllerWebApiTest.java
+++ b/src/test/java/com/selina/lending/api/controller/auth/AuthControllerWebApiTest.java
@@ -27,7 +27,8 @@ import feign.Request;
 import feign.RequestTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -39,14 +40,14 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WithMockUser
-@WebMvcTest(value = AuthController.class)
+@AutoConfigureMockMvc
+@SpringBootTest
 class AuthControllerWebApiTest {
 
     @Autowired
@@ -68,7 +69,6 @@ class AuthControllerWebApiTest {
         //When
         mockMvc.perform(
                         post("/auth/token")
-                                .with(csrf())
                                 .content(objectMapper.writeValueAsString(credentials))
                                 .contentType(APPLICATION_JSON)
                 )
@@ -91,7 +91,6 @@ class AuthControllerWebApiTest {
         //When
         mockMvc.perform(
                         post("/auth/token")
-                                .with(csrf())
                                 .content(objectMapper.writeValueAsString(credentials))
                                 .contentType(APPLICATION_JSON)
                 )

--- a/src/test/java/com/selina/lending/api/errors/ExceptionTranslatorTest.java
+++ b/src/test/java/com/selina/lending/api/errors/ExceptionTranslatorTest.java
@@ -26,7 +26,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -47,12 +46,9 @@ class ExceptionTranslatorTest {
         var invalidInputJson = "{,,][[";
 
         // When
-        mockMvc.perform(
-                        post("/api/exception-translator-test/method-argument")
-                                .with(csrf())
-                                .content(invalidInputJson)
-                                .contentType(APPLICATION_JSON)
-                )
+        mockMvc.perform(post("/api/exception-translator-test/method-argument")
+                        .content(invalidInputJson)
+                        .contentType(APPLICATION_JSON))
                 // Then
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -66,13 +62,9 @@ class ExceptionTranslatorTest {
         String emptyContent = "{}";
 
         // When
-        mockMvc.perform(
-                        post("/api/exception-translator-test/method-argument")
-                                .with(csrf())
-                                .content(emptyContent)
-                                .contentType(APPLICATION_JSON)
-                )
-
+        mockMvc.perform(post("/api/exception-translator-test/method-argument")
+                        .content(emptyContent)
+                        .contentType(APPLICATION_JSON))
                 // Then
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -90,7 +82,6 @@ class ExceptionTranslatorTest {
 
         // When
         mockMvc.perform(get("/api/exception-translator-test/access-denied-exception"))
-
                 // Then
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.type").doesNotExist())
@@ -107,7 +98,6 @@ class ExceptionTranslatorTest {
 
         // When
         mockMvc.perform(get("/api/exception-translator-test/custom-remote-resource-problem-exception"))
-
                 // Then
                 .andExpect(status().isBadGateway())
                 .andExpect(jsonPath("$.type").doesNotExist())
@@ -124,7 +114,6 @@ class ExceptionTranslatorTest {
 
         // When
         mockMvc.perform(get("/api/exception-translator-test/bad-request-exception"))
-
                 // Then
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.type").doesNotExist())
@@ -140,7 +129,6 @@ class ExceptionTranslatorTest {
 
         // When
         mockMvc.perform(get("/api/exception-translator-test/missing-servlet-request-part"))
-
                 // Then
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -155,7 +143,6 @@ class ExceptionTranslatorTest {
 
         // When
         mockMvc.perform(get("/api/exception-translator-test/missing-servlet-request-parameter"))
-
                 // Then
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -169,11 +156,7 @@ class ExceptionTranslatorTest {
         String expectedDetail = "Request method 'POST' not supported";
 
         // When
-        mockMvc.perform(
-                        post("/api/exception-translator-test/missing-servlet-request-parameter")
-                                .with(csrf())
-                )
-
+        mockMvc.perform(post("/api/exception-translator-test/missing-servlet-request-parameter"))
                 // Then
                 .andExpect(status().isMethodNotAllowed())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -188,8 +171,7 @@ class ExceptionTranslatorTest {
         String expectedValue = "test access denied!";
 
         // When
-        mockMvc
-                .perform(get("/api/exception-translator-test/access-denied"))
+        mockMvc.perform(get("/api/exception-translator-test/access-denied"))
                 // Then
                 .andExpect(status().isForbidden())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -203,8 +185,7 @@ class ExceptionTranslatorTest {
         String expectedMsg = "test authentication failed!";
 
         // When
-        mockMvc
-                .perform(get("/api/exception-translator-test/unauthorized"))
+        mockMvc.perform(get("/api/exception-translator-test/unauthorized"))
                 // Then
                 .andExpect(status().isUnauthorized())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -219,7 +200,6 @@ class ExceptionTranslatorTest {
 
         // When
         mockMvc.perform(get("/api/exception-translator-test/response-status"))
-
                 // Then
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -234,7 +214,6 @@ class ExceptionTranslatorTest {
 
         // When
         mockMvc.perform(get("/api/exception-translator-test/internal-server-error"))
-
                 // Then
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -250,7 +229,6 @@ class ExceptionTranslatorTest {
 
         //When
         mockMvc.perform(get("/api/exception-translator-test/conflict-exception"))
-
                 //Then
                 .andExpect(status().isConflict())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -266,7 +244,6 @@ class ExceptionTranslatorTest {
 
         //When
         mockMvc.perform(get("/api/exception-translator-test/feign-bad-request-exception"))
-
                 //Then
                 .andExpect(status().isBadGateway())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -282,7 +259,6 @@ class ExceptionTranslatorTest {
 
         //When
         mockMvc.perform(get("/api/exception-translator-test/feign-internal-server-error-exception"))
-
                 //Then
                 .andExpect(status().isBadGateway())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
@@ -299,7 +275,6 @@ class ExceptionTranslatorTest {
 
         //When
         mockMvc.perform(get("/api/exception-translator-test/feign-not-found-exception"))
-
                 //Then
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))


### PR DESCRIPTION
[GRO-2471](https://selina.atlassian.net/browse/GRO-2471)
The Lending API requires a CSRF token in case of a request without an Authorization header

```
{
    "title": "Forbidden",
    "status": 403,
    "detail": "Could not verify the provided CSRF token because no token was found to compare."
}
```
However, in that case, a response should be Unauthorized, but not Forbidden.

That happens because in security settings the CSRF protection is enabled. Since the service does not provide any web pages and is supposed to be called only by other services there is no need to have a CSRF protection at all.

The correct response should be
```
{
    "title": "Unauthorized",
    "status": 401,
    "detail": "Full authentication is required to access this resource"
}
```

[GRO-2471]: https://selina.atlassian.net/browse/GRO-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ