### PR TITLE
Return Unauthorized response in case of invalid client secret

### DIFF
--- a/src/main/java/com/selina/lending/exception/UnauthorizedException.java
+++ b/src/main/java/com/selina/lending/exception/UnauthorizedException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Selina Finance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.selina.lending.exception;
+
+import org.zalando.problem.AbstractThrowableProblem;
+import org.zalando.problem.Status;
+
+public class UnauthorizedException extends AbstractThrowableProblem { //NOSONAR
+
+    public UnauthorizedException(String details) {
+        super(null, "Unauthorized", Status.UNAUTHORIZED, details);
+    }
+}

--- a/src/main/java/com/selina/lending/httpclient/keycloak/KeycloakApi.java
+++ b/src/main/java/com/selina/lending/httpclient/keycloak/KeycloakApi.java
@@ -19,13 +19,7 @@ package com.selina.lending.httpclient.keycloak;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.selina.lending.httpclient.keycloak.dto.response.AuthApiTokenResponse;
-import feign.codec.Encoder;
-import feign.form.spring.SpringFormEncoder;
-import org.springframework.beans.factory.ObjectFactory;
-import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.cloud.openfeign.support.SpringEncoder;
-import org.springframework.context.annotation.Bean;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -40,22 +34,10 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 )
 public interface KeycloakApi {
 
-    @PostMapping(
-            path = "/protocol/openid-connect/token",
+    @PostMapping(path = "/protocol/openid-connect/token",
             consumes = APPLICATION_FORM_URLENCODED_VALUE,
             produces = APPLICATION_JSON_VALUE)
     AuthApiTokenResponse login(@RequestBody Map<String, ?> params);
 
-    //TODO do we need this?
-    class Configuration { // to execute Content-Type: application/x-www-form-urlencoded request
-        @Bean
-        Encoder feignFormEncoder(ObjectFactory<HttpMessageConverters> converters) {
-            return new SpringFormEncoder(new SpringEncoder(converters));
-        }
-    }
-
-    record ErrorDetails(
-            @JsonProperty("error") String error,
-            @JsonProperty("error_description") String description
-    ){}
+    record ErrorDetails(@JsonProperty("error") String error, @JsonProperty("error_description") String description){}
 }


### PR DESCRIPTION
The Lending API service endpoint /auth/token

replies 502 in case of invalid clientSecret.
```
{
    "title": "Bad Gateway",
    "status": 502,
    "detail": "Sorry, unable to process your request"
}
```

Now it should reply with Unauthorized
```
{
    "title": "Unauthorized",
    "status": 401,
    "detail": "Invalid client secret"
}
```