### PR TITLE
improvement(GRO-2442): Add missing expenditure models

### DIFF
--- a/src/main/java/com/selina/lending/api/mapper/qq/middleware/ExpenditureMapper.java
+++ b/src/main/java/com/selina/lending/api/mapper/qq/middleware/ExpenditureMapper.java
@@ -1,0 +1,11 @@
+package com.selina.lending.api.mapper.qq.middleware;
+
+import com.selina.lending.api.dto.common.ExpenditureDto;
+import com.selina.lending.httpclient.middleware.dto.common.Expenditure;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface ExpenditureMapper {
+    Expenditure mapToExpenditure(ExpenditureDto expenditureDto);
+}

--- a/src/main/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapper.java
+++ b/src/main/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapper.java
@@ -15,7 +15,8 @@ import java.util.List;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING,
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
-        uses = {QuickQuoteApplicantMapper.class, LoanInformationMapper.class, TokenService.class, OfferMapper.class})
+        uses = {QuickQuoteApplicantMapper.class, LoanInformationMapper.class, TokenService.class, OfferMapper.class,
+                ExpenditureMapper.class})
 public abstract class MiddlewareQuickQuoteApplicationRequestMapper {
 
     @Autowired
@@ -35,6 +36,7 @@ public abstract class MiddlewareQuickQuoteApplicationRequestMapper {
     @Mapping(target = "fees", source = "fees")
     @Mapping(target = "offers", source = "products")
     @Mapping(target = "partner", source = "request.partner")
+    @Mapping(target = "expenditure", source = "request.expenditure")
     public abstract QuickQuoteRequest mapToQuickQuoteRequest(QuickQuoteApplicationRequest request,
                                                              List<Product> products, Fees fees);
 }

--- a/src/main/java/com/selina/lending/api/mapper/qq/selection/QuickQuoteApplicationRequestMapper.java
+++ b/src/main/java/com/selina/lending/api/mapper/qq/selection/QuickQuoteApplicationRequestMapper.java
@@ -17,6 +17,7 @@
 
 package com.selina.lending.api.mapper.qq.selection;
 
+import com.selina.lending.api.dto.common.ExpenditureDto;
 import com.selina.lending.api.dto.common.IncomeDto;
 import com.selina.lending.api.dto.common.IncomeItemDto;
 import com.selina.lending.api.dto.common.LoanInformationDto;
@@ -28,6 +29,7 @@ import com.selina.lending.api.dto.qq.request.QuickQuotePropertyDetailsDto;
 import com.selina.lending.httpclient.middleware.dto.common.Fees;
 import com.selina.lending.httpclient.selection.dto.request.Applicant;
 import com.selina.lending.httpclient.selection.dto.request.Application;
+import com.selina.lending.httpclient.selection.dto.request.Expenditure;
 import com.selina.lending.httpclient.selection.dto.request.FilterQuickQuoteApplicationRequest;
 import com.selina.lending.httpclient.selection.dto.request.Income;
 import com.selina.lending.httpclient.selection.dto.request.LoanInformation;
@@ -77,6 +79,7 @@ public class QuickQuoteApplicationRequestMapper {
                 .loanInformation(mapLoanInformation(quickQuoteApplicationRequest.getLoanInformation()))
                 .propertyDetails(mapPropertyDetails(quickQuoteApplicationRequest.getPropertyDetails()))
                 .fees(mapFees(quickQuoteApplicationRequest.getFees()))
+                .expenditures(mapExpenditures(quickQuoteApplicationRequest.getExpenditure()))
                 .build();
     }
 
@@ -96,6 +99,20 @@ public class QuickQuoteApplicationRequestMapper {
                 .intermediaryFeeAmount(quickQuoteFeesDto.getIntermediaryFeeAmount())
                 .isAddIntermediaryFeeToLoan(quickQuoteFeesDto.getIsAddIntermediaryFeeToLoan())
                 .isAddArrangementFeeSelinaToLoan(quickQuoteFeesDto.getIsAddArrangementFeeSelinaToLoan())
+                .build();
+    }
+
+    private static List<Expenditure> mapExpenditures(List<ExpenditureDto> quickQuoteExpenditures) {
+        return quickQuoteExpenditures == null ? null : quickQuoteExpenditures.stream()
+                .map(QuickQuoteApplicationRequestMapper::mapExpenditure)
+                .toList();
+    }
+
+    private static Expenditure mapExpenditure(ExpenditureDto quickQuoteExpenditureDto) {
+        return quickQuoteExpenditureDto == null ? null : Expenditure.builder()
+                .amountDeclared(quickQuoteExpenditureDto.getAmountDeclared())
+                .expenditureType(quickQuoteExpenditureDto.getExpenditureType())
+                .frequency(quickQuoteExpenditureDto.getFrequency())
                 .build();
     }
 

--- a/src/main/java/com/selina/lending/httpclient/middleware/dto/qq/request/QuickQuoteRequest.java
+++ b/src/main/java/com/selina/lending/httpclient/middleware/dto/qq/request/QuickQuoteRequest.java
@@ -2,6 +2,7 @@ package com.selina.lending.httpclient.middleware.dto.qq.request;
 
 import com.selina.lending.api.dto.common.LeadDto;
 import com.selina.lending.httpclient.middleware.dto.common.Applicant;
+import com.selina.lending.httpclient.middleware.dto.common.Expenditure;
 import com.selina.lending.httpclient.middleware.dto.common.Fees;
 import com.selina.lending.httpclient.middleware.dto.common.LoanInformation;
 import com.selina.lending.httpclient.middleware.dto.common.Offer;
@@ -27,4 +28,5 @@ public class QuickQuoteRequest {
     private PropertyDetails propertyDetails;
     private List<Offer> offers;
     private Partner partner;
+    private List<Expenditure> expenditure;
 }

--- a/src/main/java/com/selina/lending/httpclient/selection/dto/request/Application.java
+++ b/src/main/java/com/selina/lending/httpclient/selection/dto/request/Application.java
@@ -33,4 +33,5 @@ public class Application {
     private LoanInformation loanInformation;
     private PropertyDetails propertyDetails;
     private Fees fees;
+    private List<Expenditure> expenditures;
 }

--- a/src/main/java/com/selina/lending/httpclient/selection/dto/request/Expenditure.java
+++ b/src/main/java/com/selina/lending/httpclient/selection/dto/request/Expenditure.java
@@ -1,0 +1,15 @@
+package com.selina.lending.httpclient.selection.dto.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Expenditure {
+
+    String expenditureType;
+
+    Double amountDeclared;
+
+    String frequency;
+}

--- a/src/test/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapperTest.java
+++ b/src/test/java/com/selina/lending/api/mapper/qq/middleware/MiddlewareQuickQuoteApplicationRequestMapperTest.java
@@ -6,6 +6,7 @@ import com.selina.lending.api.dto.qq.request.QuickQuoteApplicationRequest;
 import com.selina.lending.api.mapper.MapperBase;
 import com.selina.lending.httpclient.middleware.dto.common.Address;
 import com.selina.lending.httpclient.middleware.dto.common.Applicant;
+import com.selina.lending.httpclient.middleware.dto.common.Expenditure;
 import com.selina.lending.httpclient.middleware.dto.common.Fees;
 import com.selina.lending.httpclient.middleware.dto.common.Income;
 import com.selina.lending.httpclient.middleware.dto.common.Incomes;
@@ -76,6 +77,7 @@ class MiddlewareQuickQuoteApplicationRequestMapperTest extends MapperBase {
         assertPropertyDetails(middlewareCreateApplicationEvent.getPropertyDetails());
         assertOffers(middlewareCreateApplicationEvent.getOffers());
         assertPartner(middlewareCreateApplicationEvent.getPartner());
+        assertExpenditure(middlewareCreateApplicationEvent.getExpenditure());
     }
 
     @Test
@@ -286,4 +288,10 @@ class MiddlewareQuickQuoteApplicationRequestMapperTest extends MapperBase {
         assertThat(partner.getCompanyId(), equalTo(COMPANY_ID));
     }
 
+    private void assertExpenditure(List<Expenditure> expenditure) {
+        assertThat(expenditure, hasSize(1));
+
+        var theExpenditure = expenditure.get(0);
+        assertThat(theExpenditure.getExpenditureType(), equalTo(EXPENDITURE_TYPE));
+    }
 }

--- a/src/test/java/com/selina/lending/api/mapper/qq/selection/QuickQuoteApplicationRequestMapperTest.java
+++ b/src/test/java/com/selina/lending/api/mapper/qq/selection/QuickQuoteApplicationRequestMapperTest.java
@@ -19,13 +19,16 @@ package com.selina.lending.api.mapper.qq.selection;
 
 import com.selina.lending.api.mapper.MapperBase;
 import com.selina.lending.httpclient.selection.dto.request.Application;
+import com.selina.lending.httpclient.selection.dto.request.Expenditure;
 import com.selina.lending.httpclient.selection.dto.request.FilterQuickQuoteApplicationRequest;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -53,8 +56,8 @@ class QuickQuoteApplicationRequestMapperTest extends MapperBase {
         assertThat(applicationRequest.getApplication().getFees(), nullValue());
 
         assertPropertyDetails(application);
-
         assertPriorCharges(applicationRequest);
+        assertExpenditures(application.getExpenditures());
     }
 
     @Test
@@ -117,5 +120,12 @@ class QuickQuoteApplicationRequestMapperTest extends MapperBase {
         assertThat(fees.getIsAddIntermediaryFeeToLoan(), equalTo(false));
         assertThat(fees.getIsAddArrangementFeeSelinaToLoan(), equalTo(true));
         assertThat(fees.getArrangementFee(), equalTo(ARRANGEMENT_FEE));
+    }
+
+    private void assertExpenditures(List<Expenditure> expenditures) {
+        assertThat(expenditures, hasSize(1));
+
+        var expenditure = expenditures.get(0);
+        assertThat(expenditure.getExpenditureType(), equalTo(EXPENDITURE_TYPE));
     }
 }


### PR DESCRIPTION
#### Description

Title says most of it. The objective is to start sending expenditures to both ms-selection and ms-middleware-api.

#### Background Context

#### Additional Information

eg:
Accompanying materials (eg: screenshots)
Additional env vars
Anything else the team needs to know before this is released?

---
