### PR TITLE
chore(GRO-1984): Enrich request with needed data before sending to Middleware

### DIFF
--- a/src/main/java/com/selina/lending/httpclient/middleware/dto/qqcf/request/QuickQuoteCFRequest.java
+++ b/src/main/java/com/selina/lending/httpclient/middleware/dto/qqcf/request/QuickQuoteCFRequest.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Data
 public class QuickQuoteCFRequest {
     private String externalApplicationId;
+    private String sourceType;
     private String sourceAccount;
     private List<Applicant> applicants;
     private LoanInformation loanInformation;

--- a/src/test/java/com/selina/lending/api/mapper/MapperBase.java
+++ b/src/test/java/com/selina/lending/api/mapper/MapperBase.java
@@ -95,6 +95,7 @@ import com.selina.lending.httpclient.middleware.dto.common.RuleOutcome;
 import com.selina.lending.httpclient.middleware.dto.dip.response.Application;
 import com.selina.lending.httpclient.middleware.dto.dip.response.ApplicationResponse;
 import com.selina.lending.httpclient.middleware.dto.qq.request.Partner;
+import com.selina.lending.httpclient.middleware.dto.qqcf.request.QuickQuoteCFRequest;
 import com.selina.lending.httpclient.middleware.dto.qqcf.response.QuickQuoteCFResponse;
 import com.selina.lending.httpclient.selection.dto.response.FilteredQuickQuoteDecisionResponse;
 import com.selina.lending.httpclient.selection.dto.response.Product;
@@ -862,6 +863,16 @@ public abstract class MapperBase {
 
     protected ApplicationResponse getApplicationResponse() {
         return ApplicationResponse.builder().applicationType(DIP_APPLICATION_TYPE) .applicationId(APPLICATION_ID).application(getApplication()).creditCommitment(getCreditCommitment()).build();
+    }
+
+    protected QuickQuoteCFRequest getQuickQuoteCFRequest() {
+        return QuickQuoteCFRequest.builder()
+                .externalApplicationId(EXTERNAL_APPLICATION_ID)
+                .loanInformation(getLoanInformation())
+                .propertyDetails(getPropertyDetails())
+                .applicants(List.of(getApplicant()))
+                .fees(getFees())
+                .build();
     }
 
     protected QuickQuoteCFResponse getQuickQuoteCFResponse() {


### PR DESCRIPTION
[GRO-1984](https://selina.atlassian.net/browse/GRO-1984)

While calling the MW /application/quote_broker endpoint provide the next new request body params:

the new string root level “sourceType“ request body param

the new floating root level “fees.arrangementFeesDiscount“ request body param

These values should be taken from the information stored in Keycloak in the scope of the GRO-1975: [keycloak] in the "broker-client" realm specify the new "sourceType" access token claim
DONE
 

Return in a response the new floating “arrangementFee“ value for each offer.

[GRO-1984]: https://selina.atlassian.net/browse/GRO-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ