### PR TITLE
feat(GRO-2586): Add logic in Lending API to assume that Product and A…

### DIFF
--- a/src/main/java/com/selina/lending/service/FilterApplicationServiceImpl.java
+++ b/src/main/java/com/selina/lending/service/FilterApplicationServiceImpl.java
@@ -113,17 +113,17 @@ public class FilterApplicationServiceImpl implements FilterApplicationService {
     }
 
     private static boolean isClearScoreAlternativeOfferRequest(String clientId, Integer requestedLoanTerm) {
-        return CLEAR_SCORE_CLIENT_ID.equalsIgnoreCase(clientId)
+        return isClearScoreClient(clientId)
                 && requestedLoanTerm >= MIN_ALLOWED_CLEAR_SCORE_ALTERNATIVE_OFFER_LOAN_TERM
                 && isAlternativeOfferRequest(requestedLoanTerm);
     }
 
     private static boolean isMonevoAlternativeOfferRequest(String clientId, Integer requestedLoanTerm) {
-        return MONEVO_CLIENT_ID.equalsIgnoreCase(clientId) && isAlternativeOfferRequest(requestedLoanTerm);
+        return isMonevoClient(clientId) && isAlternativeOfferRequest(requestedLoanTerm);
     }
 
     private static boolean isExperianAlternativeOfferRequest(String clientId, Integer requestedLoanTerm) {
-        return EXPERIAN_CLIENT_ID.equalsIgnoreCase(clientId) && isAlternativeOfferRequest(requestedLoanTerm);
+        return isExperianClient(clientId) && isAlternativeOfferRequest(requestedLoanTerm);
     }
 
     private void adjustToAlternativeOffer(String clientId, QuickQuoteApplicationRequest request) {
@@ -157,10 +157,22 @@ public class FilterApplicationServiceImpl implements FilterApplicationService {
             requestFees.setIsAddProductFeesToFacility(ADD_PRODUCT_FEES_TO_FACILITY_DEFAULT);
         }
 
-        if (MONEVO_CLIENT_ID.equalsIgnoreCase(clientId)) {
+        if (isMonevoClient(clientId) || isClearScoreClient(clientId)) {
             requestFees.setIsAddArrangementFeeSelinaToLoan(true);
             requestFees.setIsAddProductFeesToFacility(true);
         }
+    }
+
+    private static boolean isClearScoreClient(String clientId) {
+        return CLEAR_SCORE_CLIENT_ID.equalsIgnoreCase(clientId);
+    }
+
+    private static boolean isMonevoClient(String clientId) {
+        return MONEVO_CLIENT_ID.equalsIgnoreCase(clientId);
+    }
+
+    private static boolean isExperianClient(String clientId) {
+        return EXPERIAN_CLIENT_ID.equalsIgnoreCase(clientId);
     }
 
     private void setDefaultApplicantPrimaryApplicantIfDoesNotExist(QuickQuoteApplicationRequest request) {

--- a/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
+++ b/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
@@ -519,6 +519,57 @@ class FilterApplicationServiceImplTest extends MapperBase {
         assertThat(selectionRequestFees.getIsAddArrangementFeeSelinaToLoan()).isTrue();
     }
 
+    @Test
+    void whenClientIsClearScoreAndFeesAreNotSpecifiedThenIncludeArrangementFeeSelinaAndProductFeeToTheLoan() {
+        // Given
+        var declinedDecisionResponse = FilteredQuickQuoteDecisionResponse.builder()
+                .decision("Declined")
+                .products(null)
+                .build();
+
+        when(tokenService.retrieveClientId()).thenReturn("clearscore");
+        when(arrangementFeeSelinaService.getFeesFromToken()).thenReturn(Fees.builder().build());
+        when(selectionRepository.filter(any(FilterQuickQuoteApplicationRequest.class))).thenReturn(declinedDecisionResponse);
+        var quickQuoteApplicationRequest = getQuickQuoteApplicationRequestDto();
+        var selectionRequestCaptor = ArgumentCaptor.forClass(FilterQuickQuoteApplicationRequest.class);
+
+        // When
+        filterApplicationService.filter(quickQuoteApplicationRequest);
+
+        // Then
+        verify(selectionRepository).filter(selectionRequestCaptor.capture());
+        var selectionRequestFees = selectionRequestCaptor.getValue().getApplication().getFees();
+        assertThat(selectionRequestFees.getIsAddProductFeesToFacility()).isTrue();
+        assertThat(selectionRequestFees.getIsAddArrangementFeeSelinaToLoan()).isTrue();
+    }
+
+    @Test
+    void whenClientIsClearScoreAndFeesAreSpecifiedThenOverwriteThemToIncludeArrangementFeeSelinaAndProductFeeToTheLoan() {
+        // Given
+        var declinedDecisionResponse = FilteredQuickQuoteDecisionResponse.builder()
+                .decision("Declined")
+                .products(null)
+                .build();
+
+        when(tokenService.retrieveClientId()).thenReturn("clearscore");
+        when(arrangementFeeSelinaService.getFeesFromToken()).thenReturn(Fees.builder().build());
+        when(selectionRepository.filter(any(FilterQuickQuoteApplicationRequest.class))).thenReturn(declinedDecisionResponse);
+        var quickQuoteApplicationRequest = getQuickQuoteApplicationRequestWithFeesDto();
+        quickQuoteApplicationRequest.getFees().setIsAddArrangementFeeSelinaToLoan(false);
+        quickQuoteApplicationRequest.getFees().setIsAddProductFeesToFacility(false);
+
+        var selectionRequestCaptor = ArgumentCaptor.forClass(FilterQuickQuoteApplicationRequest.class);
+
+        // When
+        filterApplicationService.filter(quickQuoteApplicationRequest);
+
+        // Then
+        verify(selectionRepository).filter(selectionRequestCaptor.capture());
+        var selectionRequestFees = selectionRequestCaptor.getValue().getApplication().getFees();
+        assertThat(selectionRequestFees.getIsAddProductFeesToFacility()).isTrue();
+        assertThat(selectionRequestFees.getIsAddArrangementFeeSelinaToLoan()).isTrue();
+    }
+
     @Nested
     class AlternativeOffer {
 


### PR DESCRIPTION
[GRO-2586](https://selina.atlassian.net/browse/GRO-2586)

**Current:**
* Currently we do not add the fees to the loan value. Hence when a customer takes out £10,000 and they pay £1,775 in fees they actually only get £8,225 in cash in their bank account. 

**Desired:**
* We would like to rather assume that the fees are added to the loan value, so that they get £10,000 in cash and have a loan of £11,775. 

**Changes:**
* Angelo recently completed some work which is captured on [this ticket](https://selina.atlassian.net/browse/GRO-2441) to add a new field on the Lending API /quickquote response body for netLoanAmount. This is the amount the customer will receive in cash after fees.
* We have also previously completed [the work for Monevo to add fees to the loan](https://selina.atlassian.net/browse/GRO-2564)
* What we now need to do is set "addArrangementFeeSelinaToLoan": true and "addProductFeesToFacility": true only for ClearScore customers.
* This means that ClearScore customers will, by default, have the fees included in the loan. 

**NOTES:**
* We should NOT release this into Production before confirming that ClearScore has already made the change to use the netLoanAmount instead of the. offerBalance field.
* They’re busy working on this during their current sprint, but we should not release the change for this ticket before they have completed that work
