### PR TITLE
fix(GRO-2616): fix new alternative offer reules for Monevo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ HELP.md
 
 ### VS Code ###
 .vscode/
+
+**/application-dev.yaml

--- a/src/main/java/com/selina/lending/service/alternativeofferr/MonevoAlternativeOfferRequestProcessor.java
+++ b/src/main/java/com/selina/lending/service/alternativeofferr/MonevoAlternativeOfferRequestProcessor.java
@@ -21,7 +21,7 @@ public class MonevoAlternativeOfferRequestProcessor extends AlternativeOfferRequ
 
     @Override
     int calculateAlternativeRequestedLoanTerm(int requestedLoanTerm) {
-        if (requestedLoanTerm <= ALTERNATIVE_OFFER_LOAN_TERM_5_YEARS) {
+        if (requestedLoanTerm < ALTERNATIVE_OFFER_LOAN_TERM_5_YEARS) {
             return ALTERNATIVE_OFFER_LOAN_TERM_5_YEARS;
         }
 

--- a/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
+++ b/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
@@ -550,8 +550,8 @@ class FilterApplicationServiceImplTest extends MapperBase {
         class Monevo {
 
             @ParameterizedTest
-            @ValueSource(ints = {1, 2, 3, 4, 5})
-            void whenClientIsMonevoAndRequestedLoanTermIsBetween1and5ThenAdjustItTo5(int requestedLoanTerm) {
+            @ValueSource(ints = {1, 2, 3, 4})
+            void whenClientIsMonevoAndRequestedLoanTermIsBetween1and4ThenAdjustItTo5(int requestedLoanTerm) {
                 // Given
                 var decisionResponse = FilteredQuickQuoteDecisionResponse.builder()
                         .decision("Declined")
@@ -577,8 +577,8 @@ class FilterApplicationServiceImplTest extends MapperBase {
             }
 
             @ParameterizedTest
-            @ValueSource(ints = {6, 7, 8, 9, 10})
-            void whenClientIsMonevoAndRequestedLoanTermIsBetween6and10ThenAdjustItTo10(int requestedLoanTerm) {
+            @ValueSource(ints = {5, 6, 7, 8, 9, 10})
+            void whenClientIsMonevoAndRequestedLoanTermIsBetween5and10ThenAdjustItTo10(int requestedLoanTerm) {
                 // Given
                 var decisionResponse = FilteredQuickQuoteDecisionResponse.builder()
                         .decision("Declined")


### PR DESCRIPTION
According to the last update, we should apply the following alternative offer rules for Monevo clients only

* if the 1 <= requestedLoanTerm <= 4 set it to 5
* if the  5 <= requestedLoanTerm <= 10 set it to 10
* if the requestedLoanTerm > 10 use the original value