### PR TITLE
chore(GRO-2629): allow alternative offers for every Monevo partner ex…

### DIFF
--- a/src/main/java/com/selina/lending/service/alternativeofferr/AlternativeOfferRequestProcessor.java
+++ b/src/main/java/com/selina/lending/service/alternativeofferr/AlternativeOfferRequestProcessor.java
@@ -7,8 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class AlternativeOfferRequestProcessor {
 
-    public void adjustAlternativeOfferRequest(String s, QuickQuoteApplicationRequest quickQuoteApplicationRequest) {
-        if (isAlternativeOfferRequest(s, quickQuoteApplicationRequest)) {
+    public void adjustAlternativeOfferRequest(String clientId, QuickQuoteApplicationRequest quickQuoteApplicationRequest) {
+        if (isAlternativeOfferRequest(clientId, quickQuoteApplicationRequest)) {
             adjustAlternativeOfferRequest(quickQuoteApplicationRequest);
         }
     }

--- a/src/main/java/com/selina/lending/service/alternativeofferr/MonevoAlternativeOfferRequestProcessor.java
+++ b/src/main/java/com/selina/lending/service/alternativeofferr/MonevoAlternativeOfferRequestProcessor.java
@@ -10,10 +10,10 @@ public class MonevoAlternativeOfferRequestProcessor extends AlternativeOfferRequ
     private static final int ALTERNATIVE_OFFER_LOAN_TERM_5_YEARS = 5;
     private static final int ALTERNATIVE_OFFER_LOAN_TERM_10_YEARS = 10;
 
-    private static final LeadDto CONFUSED_COM_PARTNER_UTM = LeadDto.builder()
+    private static final LeadDto CREDIT_KARMA_PARTNER_UTM = LeadDto.builder()
             .utmSource("aggregator")
             .utmMedium("cpc")
-            .utmCampaign("_consumer_referral___confused.com_main_")
+            .utmCampaign("_consumer_referral___creditkarma_main_")
             .build();
 
     @Override
@@ -23,7 +23,7 @@ public class MonevoAlternativeOfferRequestProcessor extends AlternativeOfferRequ
 
     @Override
     boolean isSupportedPartner(LeadDto lead) {
-        return CONFUSED_COM_PARTNER_UTM.equals(lead);
+        return !CREDIT_KARMA_PARTNER_UTM.equals(lead);
     }
 
     @Override

--- a/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
+++ b/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
@@ -550,15 +550,42 @@ class FilterApplicationServiceImplTest extends MapperBase {
         @Nested
         class Monevo {
 
-            private static final LeadDto CONFUSED_COM_PARTNER_UTM = LeadDto.builder()
+            private static final LeadDto CREDIT_KARMA_PARTNER_UTM = LeadDto.builder()
                     .utmSource("aggregator")
                     .utmMedium("cpc")
-                    .utmCampaign("_consumer_referral___confused.com_main_")
+                    .utmCampaign("_consumer_referral___creditkarma_main_")
                     .build();
 
             @ParameterizedTest
+            @ValueSource(ints = {1, 2, 3, 4})
+            void whenClientIsMonevoAndPartnerIsCreditKarmaAndRequestedLoanTermIsLessThan5ThenReturnDeclinedResponse(int requestedLoanTerm) {
+                // Given
+                var declinedDecisionResponse = FilteredQuickQuoteDecisionResponse.builder()
+                        .decision("Declined")
+                        .products(null)
+                        .build();
+
+                when(arrangementFeeSelinaService.getFeesFromToken()).thenReturn(Fees.builder().build());
+                when(selectionRepository.filter(any(FilterQuickQuoteApplicationRequest.class))).thenReturn(declinedDecisionResponse);
+
+                var quickQuoteApplicationRequest = getQuickQuoteApplicationRequestDto();
+                quickQuoteApplicationRequest.getLoanInformation().setRequestedLoanTerm(requestedLoanTerm);
+                quickQuoteApplicationRequest.setLead(CREDIT_KARMA_PARTNER_UTM);
+
+                when(tokenService.retrieveClientId()).thenReturn("monevo");
+
+                // When
+                var decisionResponse = filterApplicationService.filter(quickQuoteApplicationRequest);
+
+                // Then
+                assertThat(decisionResponse).isEqualTo(declinedDecisionResponse);
+                verify(selectionRepository, never()).filter(any(FilterQuickQuoteApplicationRequest.class));
+                verify(middlewareRepository, never()).createQuickQuoteApplication(any(QuickQuoteRequest.class));
+            }
+
+            @ParameterizedTest
             @ValueSource(ints = {5, 7, 9, 11, 15, 30})
-            void whenClientIsMonevoAndPartnerIsNotConfusedThenKeepOriginalRequestedLoanTermValue(int requestedLoanTerm) {
+            void whenClientIsMonevoAndPartnerIsCreditKarmaThenKeepOriginalRequestedLoanTermValue(int requestedLoanTerm) {
                 // Given
                 var decisionResponse = FilteredQuickQuoteDecisionResponse.builder()
                         .decision("Declined")
@@ -570,6 +597,7 @@ class FilterApplicationServiceImplTest extends MapperBase {
 
                 var quickQuoteApplicationRequest = getQuickQuoteApplicationRequestDto();
                 quickQuoteApplicationRequest.getLoanInformation().setRequestedLoanTerm(requestedLoanTerm);
+                quickQuoteApplicationRequest.setLead(CREDIT_KARMA_PARTNER_UTM);
 
                 var selectionRequestCaptor = ArgumentCaptor.forClass(FilterQuickQuoteApplicationRequest.class);
 
@@ -585,7 +613,7 @@ class FilterApplicationServiceImplTest extends MapperBase {
 
             @ParameterizedTest
             @ValueSource(ints = {1, 2, 3, 4})
-            void whenClientIsMonevoAndPartnerIsConfusedAndRequestedLoanTermIsBetween1and4ThenAdjustItTo5(int requestedLoanTerm) {
+            void whenClientIsMonevoAndRequestedLoanTermIsBetween1and4ThenAdjustItTo5(int requestedLoanTerm) {
                 // Given
                 var decisionResponse = FilteredQuickQuoteDecisionResponse.builder()
                         .decision("Declined")
@@ -596,7 +624,6 @@ class FilterApplicationServiceImplTest extends MapperBase {
                 when(selectionRepository.filter(any(FilterQuickQuoteApplicationRequest.class))).thenReturn(decisionResponse);
 
                 var quickQuoteApplicationRequest = getQuickQuoteApplicationRequestDto();
-                quickQuoteApplicationRequest.setLead(CONFUSED_COM_PARTNER_UTM);
                 quickQuoteApplicationRequest.getLoanInformation().setRequestedLoanTerm(requestedLoanTerm);
 
                 var selectionRequestCaptor = ArgumentCaptor.forClass(FilterQuickQuoteApplicationRequest.class);
@@ -613,7 +640,7 @@ class FilterApplicationServiceImplTest extends MapperBase {
 
             @ParameterizedTest
             @ValueSource(ints = {5, 6, 7, 8, 9, 10})
-            void whenClientIsMonevoAndPartnerIsConfusedAndRequestedLoanTermIsBetween5and10ThenAdjustItTo10(int requestedLoanTerm) {
+            void whenClientIsMonevoAndRequestedLoanTermIsBetween5and10ThenAdjustItTo10(int requestedLoanTerm) {
                 // Given
                 var decisionResponse = FilteredQuickQuoteDecisionResponse.builder()
                         .decision("Declined")
@@ -624,7 +651,6 @@ class FilterApplicationServiceImplTest extends MapperBase {
                 when(selectionRepository.filter(any(FilterQuickQuoteApplicationRequest.class))).thenReturn(decisionResponse);
 
                 var quickQuoteApplicationRequest = getQuickQuoteApplicationRequestDto();
-                quickQuoteApplicationRequest.setLead(CONFUSED_COM_PARTNER_UTM);
                 quickQuoteApplicationRequest.getLoanInformation().setRequestedLoanTerm(requestedLoanTerm);
 
                 var selectionRequestCaptor = ArgumentCaptor.forClass(FilterQuickQuoteApplicationRequest.class);
@@ -641,7 +667,7 @@ class FilterApplicationServiceImplTest extends MapperBase {
 
             @ParameterizedTest
             @ValueSource(ints = {11, 15, 30})
-            void whenClientIsMonevoAndPartnerIsConfusedAndRequestedLoanTermIsGreaterThan10ThenLeaveOriginalValue(int requestedLoanTerm) {
+            void whenClientIsMonevoAndRequestedLoanTermIsGreaterThan10ThenLeaveOriginalValue(int requestedLoanTerm) {
                 // Given
                 var decisionResponse = FilteredQuickQuoteDecisionResponse.builder()
                         .decision("Declined")
@@ -652,7 +678,7 @@ class FilterApplicationServiceImplTest extends MapperBase {
                 when(selectionRepository.filter(any(FilterQuickQuoteApplicationRequest.class))).thenReturn(decisionResponse);
 
                 var quickQuoteApplicationRequest = getQuickQuoteApplicationRequestDto();
-                quickQuoteApplicationRequest.setLead(CONFUSED_COM_PARTNER_UTM);
+                quickQuoteApplicationRequest.setLead(CREDIT_KARMA_PARTNER_UTM);
                 quickQuoteApplicationRequest.getLoanInformation().setRequestedLoanTerm(requestedLoanTerm);
 
                 var selectionRequestCaptor = ArgumentCaptor.forClass(FilterQuickQuoteApplicationRequest.class);


### PR DESCRIPTION
In contrast to the previous ticket [GRO-2628](https://selina.atlassian.net/browse/GRO-2628)  now we were assured that only CreditKarma does not support alternative offers, so we can change the logic to allow alternative offers for every Monevo partner except CreditKarma.