### PR TITLE
chore(GRO-2683): revert - encode applyUrl request params path for Experian only

### DIFF
--- a/src/main/java/com/selina/lending/service/enricher/ApplicationResponseEnricher.java
+++ b/src/main/java/com/selina/lending/service/enricher/ApplicationResponseEnricher.java
@@ -8,17 +8,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 @Service
 @Slf4j
 public class ApplicationResponseEnricher {
-
-    private static final String EXPERIAN_CLIENT_ID = "experian";
-    private static final String EQUALS_SIGN = "=";
-    private static final String AMPERSAND_SIGN = "&";
 
     private final String quickQuoteBaseUrl;
     private final TokenService tokenService;
@@ -46,7 +40,7 @@ public class ApplicationResponseEnricher {
 
     private String quickQuoteProductOffersApplyUrlBuilder(String externalApplicationId, String productCode) {
         String clientId = tokenService.retrieveClientId();
-        var applyUrl = UriComponentsBuilder.fromHttpUrl(quickQuoteBaseUrl)
+        return UriComponentsBuilder.fromHttpUrl(quickQuoteBaseUrl)
                 .path("/aggregator")
                 .queryParamIfPresent("externalApplicationId", Optional.ofNullable(externalApplicationId))
                 .queryParamIfPresent("productCode", Optional.ofNullable(productCode))
@@ -54,17 +48,6 @@ public class ApplicationResponseEnricher {
                 .encode()
                 .build()
                 .toString();
-
-        return isExperianClient(clientId) ? encodeRequestParamsUrlPart(applyUrl) : applyUrl;
-    }
-
-    private boolean isExperianClient(String clientId) {
-        return EXPERIAN_CLIENT_ID.equalsIgnoreCase(clientId);
-    }
-
-    private String encodeRequestParamsUrlPart(String applyUrl) {
-        return applyUrl.replaceAll(EQUALS_SIGN, URLEncoder.encode(EQUALS_SIGN, StandardCharsets.UTF_8))
-                .replaceAll(AMPERSAND_SIGN, URLEncoder.encode(AMPERSAND_SIGN, StandardCharsets.UTF_8));
     }
 
 }

--- a/src/test/java/com/selina/lending/service/enricher/ApplicationResponseEnricherTest.java
+++ b/src/test/java/com/selina/lending/service/enricher/ApplicationResponseEnricherTest.java
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -71,38 +69,6 @@ class ApplicationResponseEnricherTest {
         var expected = String.format("%s/aggregator?externalApplicationId=%s&productCode=%s&source=%s",
                 QUICK_QUOTE_BASE_URL, externalApplicationId, offerCode, source);
         assertThat(response.getOffers().get(0).getApplyUrl(), equalTo(expected));
-    }
-
-    @Test
-    void whenClientIsExperianThenEncodeRequestParamsApplyUrlPart() {
-        // given
-        var externalApplicationId = "2256349";
-        var offerCode = "HO00600";
-        var source = "experian";
-        var encodedEqualsSign = URLEncoder.encode("=", StandardCharsets.UTF_8);
-        var encodedAmpersandSign = URLEncoder.encode("&", StandardCharsets.UTF_8);
-
-        when(tokenService.retrieveClientId()).thenReturn(source);
-
-        List<ProductOfferDto> productOffersList = new ArrayList<>();
-        productOffersList.add(ProductOfferDto.builder().code(offerCode).build());
-        var response = QuickQuoteResponse
-                .builder()
-                .externalApplicationId(externalApplicationId)
-                .offers(productOffersList)
-                .build();
-
-        // when
-        enricher.enrichQuickQuoteResponseWithProductOffersApplyUrl(response);
-
-        // then
-        var expected = String.format("%s/aggregator?externalApplicationId=%s&productCode=%s&source=%s",
-                QUICK_QUOTE_BASE_URL, externalApplicationId, offerCode, source)
-                .replaceAll("=", encodedEqualsSign)
-                .replaceAll("&", encodedAmpersandSign);
-
-        assertThat(response.getOffers().get(0).getApplyUrl(), equalTo(expected));
-        System.out.println(expected);
     }
 
     @Test


### PR DESCRIPTION
Unfortunately, the agreed fix will not help, so it wasn't released and the changes were reverted.

We are waiting for the fix on their side.

So, this PR reverts these changes [GRO-2683](https://selina.atlassian.net/browse/GRO-2683)


[GRO-2683]: https://selina.atlassian.net/browse/GRO-2683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ