### PR TITLE
fix(GRO-2725): fix expenditure validation

### DIFF
--- a/src/main/java/com/selina/lending/api/dto/common/ExpenditureDto.java
+++ b/src/main/java/com/selina/lending/api/dto/common/ExpenditureDto.java
@@ -22,6 +22,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 @Builder
 @Data
 public class ExpenditureDto {
@@ -29,9 +32,14 @@ public class ExpenditureDto {
     @EnumValue(enumClass = Frequency.class)
     String frequency;
     Integer balanceDeclared;
+
+    @NotNull
     Double amountDeclared;
+
     Double paymentVerified;
     Double amountVerified;
+
+    @NotBlank
     @Schema(implementation = ExpenditureType.class)
     @EnumValue(enumClass = ExpenditureType.class)
     String expenditureType;

--- a/src/main/java/com/selina/lending/api/dto/dip/request/ApplicationRequest.java
+++ b/src/main/java/com/selina/lending/api/dto/dip/request/ApplicationRequest.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.util.List;
@@ -38,5 +39,7 @@ public class ApplicationRequest {
     @Size(min = 4, max = 100)
     @Schema(description = "a unique identifier you provide for the application")
     private String externalApplicationId;
+
+    @Valid
     private List<ExpenditureDto> expenditure;
 }

--- a/src/test/java/com/selina/lending/api/controller/QuickQuoteControllerValidationTest.java
+++ b/src/test/java/com/selina/lending/api/controller/QuickQuoteControllerValidationTest.java
@@ -485,6 +485,68 @@ class QuickQuoteControllerValidationTest extends MapperBase {
                     .andExpect(jsonPath("$.violations[0].message").value("should be equal to applicants size"));
         }
 
+        @Test
+        void whenCreateQQApplicationWithoutSpecifiedExpenditureAmountDeclaredThenReturnBadRequest() throws Exception {
+            //Given
+            var request = getQuickQuoteApplicationRequestDto();
+            request.getExpenditure().get(0).setAmountDeclared(null);
+
+            when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
+
+            //When
+            mockMvc.perform(post("/application/quickquote")
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(APPLICATION_JSON))
+                    // Then
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                    .andExpect(jsonPath("$.title").value("Constraint Violation"))
+                    .andExpect(jsonPath("$.violations", hasSize(1)))
+                    .andExpect(jsonPath("$.violations[0].field").value("expenditure[0].amountDeclared"))
+                    .andExpect(jsonPath("$.violations[0].message").value("must not be null"));
+        }
+
+        @Test
+        void whenCreateQQApplicationWithoutSpecifiedExpenditureTypeThenReturnBadRequest() throws Exception {
+            //Given
+            var request = getQuickQuoteApplicationRequestDto();
+            request.getExpenditure().get(0).setExpenditureType(null);
+
+            when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
+
+            //When
+            mockMvc.perform(post("/application/quickquote")
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(APPLICATION_JSON))
+                    // Then
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                    .andExpect(jsonPath("$.title").value("Constraint Violation"))
+                    .andExpect(jsonPath("$.violations", hasSize(1)))
+                    .andExpect(jsonPath("$.violations[0].field").value("expenditure[0].expenditureType"))
+                    .andExpect(jsonPath("$.violations[0].message").value("must not be blank"));
+        }
+
+        @Test
+        void whenCreateQQApplicationWithIncorrectExpenditureTypeValueThenReturnBadRequest() throws Exception {
+            //Given
+            var request = getQuickQuoteApplicationRequestDto();
+            request.getExpenditure().get(0).setExpenditureType("some unsupported value");
+
+            when(filterApplicationService.filter(request)).thenReturn(getFilteredQuickQuoteDecisionResponse());
+
+            //When
+            mockMvc.perform(post("/application/quickquote")
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(APPLICATION_JSON))
+                    // Then
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                    .andExpect(jsonPath("$.title").value("Constraint Violation"))
+                    .andExpect(jsonPath("$.violations", hasSize(1)))
+                    .andExpect(jsonPath("$.violations[0].field").value("expenditure[0].expenditureType"))
+                    .andExpect(jsonPath("$.violations[0].message").value("value is not valid"));
+        }
     }
 
     @Nested

--- a/src/test/java/com/selina/lending/api/validator/EnumValueImplTest.java
+++ b/src/test/java/com/selina/lending/api/validator/EnumValueImplTest.java
@@ -80,7 +80,11 @@ class EnumValueImplTest {
     @Test
     void validateExpenditure() {
         //Given
-        var expenditure = ExpenditureDto.builder().expenditureType(INVALID_VALUE).frequency(INVALID_VALUE).build();
+        var expenditure = ExpenditureDto.builder()
+                .amountDeclared(1000.0)
+                .expenditureType(INVALID_VALUE)
+                .frequency(INVALID_VALUE)
+                .build();
 
         //When
         var violations = validator.validate(expenditure);


### PR DESCRIPTION
[GRO-2725](https://selina.atlassian.net/browse/GRO-2725)

While creating applications via the Lending API service if at least one expenditure item is specified it must contain both properties:
* expenditureType
* amountDeclared

[GRO-2725]: https://selina.atlassian.net/browse/GRO-2725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ