### PR TITLE
ST-2150: Return a Decline response with no offers

### DIFF
--- a/src/main/java/com/selina/lending/api/mapper/qq/adp/QuickQuoteEligibilityApplicationRequestMapper.java
+++ b/src/main/java/com/selina/lending/api/mapper/qq/adp/QuickQuoteEligibilityApplicationRequestMapper.java
@@ -61,7 +61,7 @@ public class QuickQuoteEligibilityApplicationRequestMapper {
         if (propertyDetailsDto != null && propertyDetailsDto.getPriorCharges() != null) {
             PriorChargesDto priorChargesDto = propertyDetailsDto.getPriorCharges();
             priorCharges = PriorCharges.builder()
-                    .numberPriorCharges(propertyDetailsDto.getNumberOfPriorCharges())
+                    .numberOfPriorCharges(propertyDetailsDto.getNumberOfPriorCharges())
                     .monthlyPayment(priorChargesDto.getMonthlyPayment())
                     .balanceOutstanding(priorChargesDto.getBalanceOutstanding())
                     .balanceConsolidated(priorChargesDto.getBalanceConsolidated())

--- a/src/main/java/com/selina/lending/httpclient/adp/dto/request/PriorCharges.java
+++ b/src/main/java/com/selina/lending/httpclient/adp/dto/request/PriorCharges.java
@@ -26,6 +26,6 @@ public class PriorCharges {
     Double balanceConsolidated;
     Double balanceOutstanding;
     Double monthlyPayment;
-    Integer numberPriorCharges;
+    Integer numberOfPriorCharges;
     Double otherDebtPayments;
 }

--- a/src/main/java/com/selina/lending/service/FilterApplicationServiceImpl.java
+++ b/src/main/java/com/selina/lending/service/FilterApplicationServiceImpl.java
@@ -136,8 +136,10 @@ public class FilterApplicationServiceImpl implements FilterApplicationService {
                 adpResponse.setProducts(getFilteredResponseOffers(clientId, adpResponse.getProducts()));
                 enrichOffersWithEligibilityAndRequestWithPropertyEstimatedValue(request, adpResponse.getProducts());
                 storeOffersInMiddleware(request, adpRequest.getApplication().getFees(), adpResponse.getProducts());
+                quickQuoteResponse = QuickQuoteEligibilityApplicationResponseMapper.INSTANCE.mapToQuickQuoteResponse(adpResponse);
+            } else {
+                quickQuoteResponse = getDeclinedResponse();
             }
-            quickQuoteResponse = QuickQuoteEligibilityApplicationResponseMapper.INSTANCE.mapToQuickQuoteResponse(adpResponse);
         } else {
             FilterQuickQuoteApplicationRequest selectionRequest = QuickQuoteApplicationRequestMapper.mapRequest(request);
             enrichSelectionRequestWithFees(selectionRequest, clientId);

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -12,7 +12,7 @@
         </encoder>
     </appender>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="Console"/>
     </root>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -12,7 +12,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="debug">
         <appender-ref ref="Console"/>
     </root>
 

--- a/src/test/java/com/selina/lending/api/mapper/qq/adp/QuickQuoteEligibilityApplicationRequestMapperTest.java
+++ b/src/test/java/com/selina/lending/api/mapper/qq/adp/QuickQuoteEligibilityApplicationRequestMapperTest.java
@@ -112,7 +112,7 @@ class QuickQuoteEligibilityApplicationRequestMapperTest extends MapperBase {
 
     private void assertPriorCharges(QuickQuoteEligibilityApplicationRequest applicationRequest) {
         var priorCharges = applicationRequest.getApplication().getPropertyDetails().getPriorCharges();
-        assertThat(priorCharges.getNumberPriorCharges(), equalTo(1));
+        assertThat(priorCharges.getNumberOfPriorCharges(), equalTo(1));
         assertThat(priorCharges.getMonthlyPayment(), equalTo(MONTHLY_PAYMENT));
         assertThat(priorCharges.getBalanceOutstanding(), equalTo(OUTSTANDING_BALANCE));
         assertThat(priorCharges.getBalanceConsolidated(), equalTo(BALANCE_CONSOLIDATED));

--- a/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
+++ b/src/test/java/com/selina/lending/service/FilterApplicationServiceImplTest.java
@@ -825,7 +825,6 @@ class FilterApplicationServiceImplTest extends MapperBase {
             verify(adpGatewayRepository, times(1)).quickQuoteEligibility(any(QuickQuoteEligibilityApplicationRequest.class));
             verify(middlewareRepository, times(0)).createQuickQuoteApplication(any(QuickQuoteRequest.class));
             assertThat(response.getStatus()).isEqualTo("Declined");
-            assertThat(response.getOffers()).hasSize(decisionResponse.getProducts().size());
         }
 
         @Test
@@ -906,7 +905,7 @@ class FilterApplicationServiceImplTest extends MapperBase {
             when(partnerService.getPartnerFromToken()).thenReturn(null);
 
             //When
-            var response = filterApplicationService.filter(getQuickQuoteApplicationRequestDto());
+            filterApplicationService.filter(getQuickQuoteApplicationRequestDto());
 
             //Then
             verify(middlewareRepository, times(1)).createQuickQuoteApplication(qqMiddlewareRequestCaptor.capture());


### PR DESCRIPTION
#### Description

When we get a declined response, we should return a simple decline response with no offers so that it mimicks what the existing selection service is doing.

#### Background Context

#### Additional Information

eg:
Accompanying materials (eg: screenshots)
Additional env vars
Anything else the team needs to know before this is released?

---
