### PR TITLE
chore(GRO-2894): expose netLoanAmount for DIP and DIPCC applications

### DIFF
--- a/src/main/java/com/selina/lending/api/dto/common/OfferDto.java
+++ b/src/main/java/com/selina/lending/api/dto/common/OfferDto.java
@@ -64,6 +64,7 @@ public class OfferDto {
     String ercShortCode;
     Integer ercPeriodYears;
     Double maximumBalanceEsis;
+    Double netLoanAmount;
     Double maxErc;
     List<ErcDto> ercData;
     @Schema(description = "Rule outcomes for Decline and Refer decisions (only DIP applications)")

--- a/src/test/java/com/selina/lending/api/mapper/qq/middleware/OfferMapperTest.java
+++ b/src/test/java/com/selina/lending/api/mapper/qq/middleware/OfferMapperTest.java
@@ -90,6 +90,7 @@ class OfferMapperTest extends MapperBase {
         assertThat(offer.getFixedTermYears(), equalTo(FIXED_TERM_YEARS));
         assertThat(offer.getMinimumInitialDrawdown(), equalTo(MINIMUM_INITIAL_DRAWDOWN));
         assertThat(offer.getOfferValidity(), equalTo(OFFER_VALIDITY));
+        assertThat(offer.getNetLoanAmount(), equalTo(NET_LOAN_AMOUNT));
         assertThat(offer.getEsisLoanAmount(), equalTo(ESIS_LOAN_AMOUNT));
         assertThat(offer.getArrangementFeeSelina(), equalTo(ARRANGEMENT_FEE_SELINA));
         assertErcData(offer.getErcData());


### PR DESCRIPTION
[GRO-2894](https://selina.atlassian.net/browse/GRO-2894)

Expose offers netLoanAmound for DIP with Prior charges and DIP CC applications


[GRO-2894]: https://selina.atlassian.net/browse/GRO-2894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ